### PR TITLE
feat: add server runtime support for pure Dart environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.1.3] - 2025-12-16
+
+### Added
+- **Server Runtime Support** - New `runtime_server.dart` entry point for pure Dart server environments
+  - Use `import 'package:prisma_flutter_connector/runtime_server.dart'` in Dart Frog, Shelf, or other server frameworks
+  - Exports only PostgreSQL and Supabase adapters (no Flutter/sqflite dependencies)
+  - Fixes "dart:ui not available" errors when using the package in server environments
+
+### Why This Matters
+The main `runtime.dart` exports the SQLite adapter which depends on `sqflite` (a Flutter plugin).
+When imported in pure Dart servers, this caused compilation errors because `sqflite` imports `dart:ui`.
+
+Now you can:
+- Use `runtime_server.dart` for Dart servers (Dart Frog, Shelf, etc.)
+- Use `runtime.dart` for Flutter apps (includes SQLite for offline-first mobile)
+
+### Usage
+
+```dart
+// In Dart Frog backend:
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+// In Flutter app:
+import 'package:prisma_flutter_connector/runtime.dart';
+```
+
+---
+
 ## [0.1.2] - 2025-12-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Run:
 flutter pub get
 ```
 
+### Server Usage (Dart Frog, Shelf, etc.)
+
+For pure Dart server environments, use the server-specific import to avoid Flutter dependencies:
+
+```dart
+// In your Dart server (Dart Frog, Shelf, etc.)
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+// For Flutter apps (includes SQLite support)
+import 'package:prisma_flutter_connector/runtime.dart';
+```
+
+The `runtime_server.dart` exports only PostgreSQL and Supabase adapters, which use the pure Dart `postgres` package. This avoids the `dart:ui not available` error that occurs when the SQLite adapter (which depends on Flutter's `sqflite`) is imported in server environments.
+
 ## Quick Start
 
 ### 1. Create Your Prisma Schema

--- a/lib/runtime_server.dart
+++ b/lib/runtime_server.dart
@@ -1,0 +1,94 @@
+/// Prisma Flutter Connector - Server Runtime Library
+///
+/// This library provides the runtime components for pure Dart server environments
+/// (Dart Frog, Shelf, etc.) without Flutter dependencies.
+///
+/// **Use this instead of `runtime.dart` when:**
+/// - Building Dart Frog backends
+/// - Building Shelf/Alfred servers
+/// - Any pure Dart server environment
+///
+/// **Use `runtime.dart` when:**
+/// - Building Flutter mobile/web apps
+/// - Need SQLite support for offline-first mobile apps
+///
+/// ## Why This Exists
+///
+/// The main `runtime.dart` exports the SQLite adapter which depends on `sqflite`,
+/// a Flutter plugin that imports `dart:ui`. This causes compilation errors in
+/// pure Dart environments where Flutter SDK is not available.
+///
+/// This library exports only the PostgreSQL and Supabase adapters which use the
+/// pure Dart `postgres` package.
+///
+/// ## Supported Databases
+///
+/// - **PostgreSQL** via `postgres` package
+/// - **Supabase** (PostgreSQL with direct connection)
+///
+/// ## Usage
+///
+/// ```dart
+/// // In your Dart Frog backend:
+/// import 'package:prisma_flutter_connector/runtime_server.dart';
+/// import 'package:postgres/postgres.dart' as pg;
+///
+/// // Connect to database
+/// final connection = await pg.Connection.open(
+///   pg.Endpoint(
+///     host: 'localhost',
+///     database: 'mydb',
+///     username: 'user',
+///     password: 'password',
+///   ),
+/// );
+///
+/// // Create adapter
+/// final adapter = PostgresAdapter(connection);
+/// final executor = QueryExecutor(adapter: adapter);
+///
+/// // Build and execute query
+/// final query = JsonQueryBuilder()
+///     .model('User')
+///     .action(QueryAction.findMany)
+///     .where({'email': FilterOperators.contains('@example.com')})
+///     .orderBy({'createdAt': 'desc'})
+///     .build();
+///
+/// final users = await executor.executeQueryAsMaps(query);
+/// print('Found ${users.length} users');
+/// ```
+///
+/// ## Supabase Connection
+///
+/// ```dart
+/// final adapter = await SupabaseAdapter.fromConnectionString(
+///   'postgresql://user:pass@host:6543/db?pgbouncer=true',
+/// );
+/// final executor = QueryExecutor(adapter: adapter);
+/// ```
+///
+/// ## Transactions
+///
+/// ```dart
+/// await executor.executeInTransaction((tx) async {
+///   await tx.executeMutation(createUserQuery);
+///   await tx.executeMutation(createProfileQuery);
+///   // Both succeed or both rollback
+/// });
+/// ```
+library prisma_flutter_connector.runtime_server;
+
+// Core adapter types (pure Dart - no Flutter dependencies)
+export 'src/runtime/adapters/types.dart';
+
+// Server-safe database adapters (use only `postgres` package)
+export 'src/runtime/adapters/postgres_adapter.dart';
+export 'src/runtime/adapters/supabase_adapter.dart';
+// Note: SQLite adapter is NOT exported here as it requires Flutter's sqflite package
+// Use `runtime.dart` instead if you need SQLite support in a Flutter app
+
+// Query building (pure Dart - no Flutter dependencies)
+export 'src/runtime/query/json_protocol.dart';
+export 'src/runtime/query/sql_compiler.dart';
+export 'src/runtime/query/query_executor.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues


### PR DESCRIPTION
## Summary

Adds `runtime_server.dart` entry point for pure Dart server environments (Dart Frog, Shelf, etc.) that exports only PostgreSQL and Supabase adapters.

## Problem

When using `prisma_flutter_connector` in a pure Dart server environment like Dart Frog, the main `runtime.dart` import causes compilation errors:

```
Error: Dart library 'dart:ui' is not available on this platform.
```

This happens because `runtime.dart` exports `sqlite_adapter.dart` which imports `sqflite`, a Flutter plugin that depends on `dart:ui`.

## Solution

Add a new `runtime_server.dart` entry point that:
- Exports only PostgreSQL and Supabase adapters (which use the pure Dart `postgres` package)
- Excludes the SQLite adapter (which requires Flutter)
- Maintains full backward compatibility with existing `runtime.dart`

## Usage

```dart
// In Dart Frog backend:
import 'package:prisma_flutter_connector/runtime_server.dart';

// In Flutter app:
import 'package:prisma_flutter_connector/runtime.dart';
```

## Changes

- Add `lib/runtime_server.dart` - Server-safe runtime export
- Update `pubspec.yaml` - Bump version to 0.1.3
- Update `CHANGELOG.md` - Document the new feature
- Update `README.md` - Add server usage documentation

## Testing

- [x] `flutter analyze` passes for both `runtime.dart` and `runtime_server.dart`
- [ ] Tested in Dart Frog backend (familiarise_mobile/backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)