### PR TITLE
fix(transaction): Add relation deserialization to TransactionExecutor [v0.3.4]

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues


### PR DESCRIPTION
## Summary

Fixes a critical bug where `TransactionExecutor.executeQueryAsMaps()` was returning flat maps with aliased column names instead of properly nested relation objects when using `include()`.

### The Problem
When executing queries with `include()` inside a transaction, the results were flattened:
```dart
// Before: Flat map with aliased keys
{'consultationPlanTitle': 'Basic Plan', 'consultationPlanPrice': 100}
```

### The Solution
Added `RelationDeserializer` logic to `TransactionExecutor`, matching the existing implementation in `QueryExecutor`:
```dart
// After: Properly nested relations
{'consultationPlan': {'title': 'Basic Plan', 'price': 100}}
```

## Changes

- Added optional `schema` parameter to `TransactionExecutor`
- Implemented relation deserialization using `RelationDeserializer`
- Added `_deserializeValue` method for proper DateTime, Date, Boolean, and JSON type conversion
- Updated `_resultSetToMaps` with `preserveAliases` parameter
- Updated `executeInTransaction` to pass schema to `TransactionExecutor`

## Test Plan

- [x] Ran `dart analyze` - no errors (only info-level issues in tmp/ demo files)
- [x] Ran `dart format` - code properly formatted
- [x] Tested with familiarise backend using local path dependency
- [x] Verified booking details API returns properly nested relation data
- [x] Verified appointments list API returns correct nested structures

## Breaking Changes

None - this is a backwards-compatible fix. Existing code will continue to work, but now transactions with `include()` will properly deserialize relations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)