### PR TITLE
feat: v0.5.1 — zero buf.write, full code_builder for all generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-28
+
+### Changed
+
+#### Zero StringBuffer — Full code_builder Migration
+- **Rewrote `cb_model_generator` and `cb_filter_types_generator`** to use code_builder Class/Constructor/Parameter/Enum builders
+- All 5 generators now have **0 `buf.write` calls** (was 167 in v0.5.0, 917 in v0.4.0)
+- Freezed classes generated via code_builder AST: `@freezed`, `with _$Model`, `const factory ... = _Model`, `fromJson`
+- Field annotations (`@Default`, `@JsonKey`, `@JsonSerializable`) built as `CodeExpression` nodes
+
+#### Freezed Dependency
+- Constrained `freezed` dev dependency to `>=3.0.6 <3.2.0` (3.2.x requires Dart SDK >=3.7.0)
+
 ## [0.5.0] - 2026-03-28
 
 ### Changed

--- a/lib/src/generator/cb_filter_types_generator.dart
+++ b/lib/src/generator/cb_filter_types_generator.dart
@@ -1,143 +1,148 @@
-/// Filter types generator using code_builder for auto-formatted output.
+/// Filter types generator using code_builder — zero StringBuffer usage.
 // ignore_for_file: prefer_const_constructors
 library;
 
+import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
 import 'package:prisma_flutter_connector/src/generator/string_utils.dart';
 
-/// Generates filter type classes (StringFilter, IntFilter, etc.)
-/// using dart_style for auto-formatting.
+/// Generates filter type classes using code_builder AST.
 class CbFilterTypesGenerator {
   final PrismaSchema schema;
   late final _formatter =
       DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+  final _emitter = DartEmitter(useNullSafetySyntax: true);
 
   CbFilterTypesGenerator(this.schema);
 
   String generate() {
-    final buf = StringBuffer();
+    final directives = <Directive>[
+      Directive.import('package:freezed_annotation/freezed_annotation.dart'),
+      ...schema.enums
+          .map((e) => Directive.import('models/${toSnakeCase(e.name)}.dart')),
+      Directive.part('filters.freezed.dart'),
+      Directive.part('filters.g.dart'),
+    ];
 
-    buf.writeln('/// Generated filter types for type-safe queries');
-    buf.writeln('library;');
-    buf.writeln();
-    buf.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
-    buf.writeln();
+    final body = <Spec>[
+      _filter('StringFilter', 'String', [
+        _p('String?', 'equals'),
+        _p('String?', 'not'),
+        _pJsonKey('List<String>?', 'in_', 'in'),
+        _p('List<String>?', 'notIn'),
+        _p('String?', 'contains'),
+        _p('String?', 'startsWith'),
+        _p('String?', 'endsWith'),
+        _p('String?', 'lt'),
+        _p('String?', 'lte'),
+        _p('String?', 'gt'),
+        _p('String?', 'gte'),
+      ]),
+      _filter('IntFilter', 'Int', [
+        _p('int?', 'equals'),
+        _p('int?', 'not'),
+        _pJsonKey('List<int>?', 'in_', 'in'),
+        _p('List<int>?', 'notIn'),
+        _p('int?', 'lt'),
+        _p('int?', 'lte'),
+        _p('int?', 'gt'),
+        _p('int?', 'gte'),
+      ]),
+      _filter('FloatFilter', 'Float/Decimal', [
+        _p('double?', 'equals'),
+        _p('double?', 'not'),
+        _pJsonKey('List<double>?', 'in_', 'in'),
+        _p('List<double>?', 'notIn'),
+        _p('double?', 'lt'),
+        _p('double?', 'lte'),
+        _p('double?', 'gt'),
+        _p('double?', 'gte'),
+      ]),
+      _filter('BooleanFilter', 'Boolean', [
+        _p('bool?', 'equals'),
+        _p('bool?', 'not'),
+      ]),
+      _filter('DateTimeFilter', 'DateTime', [
+        _p('DateTime?', 'equals'),
+        _p('DateTime?', 'not'),
+        _pJsonKey('List<DateTime>?', 'in_', 'in'),
+        _p('List<DateTime>?', 'notIn'),
+        _p('DateTime?', 'lt'),
+        _p('DateTime?', 'lte'),
+        _p('DateTime?', 'gt'),
+        _p('DateTime?', 'gte'),
+      ]),
+      ...schema.enums.map((e) => _filter('${e.name}Filter', e.name, [
+            _p('${e.name}?', 'equals'),
+            _p('${e.name}?', 'not'),
+            _pJsonKey('List<${e.name}>?', 'in_', 'in'),
+            _p('List<${e.name}>?', 'notIn'),
+          ])),
+      _filter('StringListFilter', 'String list', [
+        _p('String?', 'has'),
+        _p('List<String>?', 'hasEvery'),
+        _p('List<String>?', 'hasSome'),
+        _p('bool?', 'isEmpty'),
+      ]),
+      _filter('IntListFilter', 'Int list', [
+        _p('int?', 'has'),
+        _p('List<int>?', 'hasEvery'),
+        _p('List<int>?', 'hasSome'),
+        _p('bool?', 'isEmpty'),
+      ]),
+      Enum((b) => b
+        ..name = 'SortOrder'
+        ..docs.add('/// Sort order for ordering results')
+        ..values.addAll([
+          EnumValue((v) => v
+            ..name = 'asc'
+            ..annotations.add(CodeExpression(Code("JsonValue('asc')")))),
+          EnumValue((v) => v
+            ..name = 'desc'
+            ..annotations.add(CodeExpression(Code("JsonValue('desc')")))),
+        ])),
+    ];
 
-    for (final enumDef in schema.enums) {
-      buf.writeln("import 'models/${toSnakeCase(enumDef.name)}.dart';");
-    }
-    if (schema.enums.isNotEmpty) buf.writeln();
+    final library = Library((b) => b
+      ..comments.add('/// Generated filter types for type-safe queries')
+      ..directives.addAll(directives)
+      ..body.addAll(body));
 
-    buf.writeln("part 'filters.freezed.dart';");
-    buf.writeln("part 'filters.g.dart';");
-    buf.writeln();
+    return _formatter.format('${library.accept(_emitter)}');
+  }
 
-    // Core filters
-    buf.write(_freezedFilter('StringFilter', 'String', [
-      'String? equals',
-      'String? not',
-      "@JsonKey(name: 'in') List<String>? in_",
-      'List<String>? notIn',
-      'String? contains',
-      'String? startsWith',
-      'String? endsWith',
-      'String? lt',
-      'String? lte',
-      'String? gt',
-      'String? gte',
-    ]));
-
-    buf.write(_freezedFilter('IntFilter', 'Int', [
-      'int? equals',
-      'int? not',
-      "@JsonKey(name: 'in') List<int>? in_",
-      'List<int>? notIn',
-      'int? lt',
-      'int? lte',
-      'int? gt',
-      'int? gte',
-    ]));
-
-    buf.write(_freezedFilter('FloatFilter', 'Float/Decimal', [
-      'double? equals',
-      'double? not',
-      "@JsonKey(name: 'in') List<double>? in_",
-      'List<double>? notIn',
-      'double? lt',
-      'double? lte',
-      'double? gt',
-      'double? gte',
-    ]));
-
-    buf.write(_freezedFilter('BooleanFilter', 'Boolean', [
-      'bool? equals',
-      'bool? not',
-    ]));
-
-    buf.write(_freezedFilter('DateTimeFilter', 'DateTime', [
-      'DateTime? equals',
-      'DateTime? not',
-      "@JsonKey(name: 'in') List<DateTime>? in_",
-      'List<DateTime>? notIn',
-      'DateTime? lt',
-      'DateTime? lte',
-      'DateTime? gt',
-      'DateTime? gte',
-    ]));
-
-    // Enum filters
-    for (final enumDef in schema.enums) {
-      buf.write(_freezedFilter('${enumDef.name}Filter', enumDef.name, [
-        '${enumDef.name}? equals',
-        '${enumDef.name}? not',
-        "@JsonKey(name: 'in') List<${enumDef.name}>? in_",
-        'List<${enumDef.name}>? notIn',
+  Class _filter(String name, String doc, List<Parameter> params) {
+    return Class((b) => b
+      ..name = name
+      ..docs.add('/// Filter for $doc fields')
+      ..annotations.add(refer('freezed'))
+      ..mixins.add(refer('_\$$name'))
+      ..constructors.addAll([
+        Constructor((c) => c
+          ..factory = true
+          ..constant = true
+          ..redirect = refer('_$name')
+          ..optionalParameters.addAll(params)),
+        Constructor((c) => c
+          ..factory = true
+          ..name = 'fromJson'
+          ..requiredParameters.add(Parameter((p) => p
+            ..name = 'json'
+            ..type = refer('Map<String, dynamic>')))
+          ..body = Code('return _\$${name}FromJson(json);')),
       ]));
-    }
-
-    // List filters
-    buf.write(_freezedFilter('StringListFilter', 'String list', [
-      'String? has',
-      'List<String>? hasEvery',
-      'List<String>? hasSome',
-      'bool? isEmpty',
-    ]));
-
-    buf.write(_freezedFilter('IntListFilter', 'Int list', [
-      'int? has',
-      'List<int>? hasEvery',
-      'List<int>? hasSome',
-      'bool? isEmpty',
-    ]));
-
-    // SortOrder enum
-    buf.writeln('/// Sort order for ordering results');
-    buf.writeln('enum SortOrder {');
-    buf.writeln("  @JsonValue('asc')");
-    buf.writeln('  asc,');
-    buf.writeln("  @JsonValue('desc')");
-    buf.writeln('  desc,');
-    buf.writeln('}');
-
-    return _formatter.format(buf.toString());
   }
 
-  String _freezedFilter(String name, String doc, List<String> fields) {
-    final buf = StringBuffer();
-    buf.writeln('/// Filter for $doc fields');
-    buf.writeln('@freezed');
-    buf.writeln('class $name with _\$$name {');
-    buf.writeln('  const factory $name({');
-    for (final field in fields) {
-      buf.writeln('    $field,');
-    }
-    buf.writeln('  }) = _$name;');
-    buf.writeln();
-    buf.writeln('  factory $name.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${name}FromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
-  }
+  Parameter _p(String type, String name) => Parameter((p) => p
+    ..name = name
+    ..named = true
+    ..type = refer(type));
+
+  Parameter _pJsonKey(String type, String name, String jsonName) =>
+      Parameter((p) => p
+        ..name = name
+        ..named = true
+        ..type = refer(type)
+        ..annotations.add(CodeExpression(Code("JsonKey(name: '$jsonName')"))));
 }

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -1,10 +1,12 @@
 /// Model generator using code_builder for type-safe AST generation.
 ///
 /// Generates Freezed model files, input types, filter types, and enums
-/// from Prisma schema definitions.
+/// from Prisma schema definitions. All classes built with code_builder
+/// Class/Constructor/Parameter builders — zero StringBuffer usage.
 // ignore_for_file: prefer_const_constructors
 library;
 
+import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
 import 'package:prisma_flutter_connector/src/generator/string_utils.dart';
@@ -14,316 +16,315 @@ class CbModelGenerator {
   final PrismaSchema schema;
   late final _formatter =
       DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+  final _emitter = DartEmitter(useNullSafetySyntax: true);
 
   CbModelGenerator(this.schema);
 
-  /// Generate Dart code for a single model.
-  ///
-  /// Because Freezed models require specific annotation patterns (`@freezed`,
-  /// `part` directives, `_$` prefixed mixins) that code_builder doesn't
-  /// natively support, we use a hybrid approach: code_builder for imports and
-  /// structure, but Code() blocks for the Freezed-specific class bodies.
   String generateModel(PrismaModel model) {
-    // Freezed models have very specific syntax requirements that are easier
-    // to handle with targeted string generation inside code_builder Code blocks.
-    // The key benefit of code_builder here is auto-formatting and structured imports.
-    final buf = StringBuffer();
+    final sn = toSnakeCase(model.name);
 
-    // Imports
-    buf.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
-    buf.writeln();
-    buf.writeln("import '../filters.dart';");
-    buf.writeln();
-
-    // Model/enum type imports
-    final imports = <String>{};
-    for (final field in model.fields) {
-      if (!_isPrimitiveType(field.type)) imports.add(field.type);
+    // Collect non-primitive type imports
+    final typeImports = <String>{};
+    for (final f in model.fields) {
+      if (!_isPrimitiveType(f.type)) typeImports.add(f.type);
     }
-    for (final imp in imports) {
-      buf.writeln("import '${toSnakeCase(imp)}.dart';");
-    }
-    if (imports.isNotEmpty) buf.writeln();
 
-    // Part files
-    buf.writeln("part '${toSnakeCase(model.name)}.freezed.dart';");
-    buf.writeln("part '${toSnakeCase(model.name)}.g.dart';");
-    buf.writeln();
+    final directives = <Directive>[
+      Directive.import('package:freezed_annotation/freezed_annotation.dart'),
+      Directive.import('../filters.dart'),
+      ...typeImports.map((t) => Directive.import('${toSnakeCase(t)}.dart')),
+      Directive.part('$sn.freezed.dart'),
+      Directive.part('$sn.g.dart'),
+    ];
 
-    // Main model class
-    buf.writeln('@freezed');
-    buf.writeln('class ${model.name} with _\$${model.name} {');
-    buf.writeln('  const factory ${model.name}({');
-    for (final field in model.fields) {
-      buf.write(_generateModelField(field));
-    }
-    buf.writeln('  }) = _${model.name};');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}FromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
+    final library = Library((b) => b
+      ..directives.addAll(directives)
+      ..body.addAll([
+        _buildMainClass(model),
+        _buildCreateInput(model),
+        _buildUpdateInput(model),
+        ..._buildWhereUniqueInput(model),
+        _buildWhereInput(model),
+        _buildListRelationFilter(model),
+        _buildRelationFilter(model),
+        _buildOrderByInput(model),
+      ]));
 
-    // Input types
-    buf.write(_generateCreateInput(model));
-    buf.write(_generateUpdateInput(model));
-    buf.write(_generateWhereUniqueInput(model));
-    buf.write(_generateWhereInput(model));
-    buf.write(_generateRelationFilters(model));
-    buf.write(_generateOrderByInput(model));
-
-    return _formatter.format(buf.toString());
+    return _formatter.format('${library.accept(_emitter)}');
   }
 
-  String _generateModelField(PrismaField field) {
-    final buf = StringBuffer();
+  // === Main model class ===
 
-    if (field.isRelation) {
-      buf.writeln('    @JsonKey(includeFromJson: false, includeToJson: false)');
-      final type = field.isList ? 'List<${field.type}>' : field.type;
-      buf.writeln('    $type? ${field.name},');
-      return buf.toString();
+  Class _buildMainClass(PrismaModel model) {
+    final params = <Parameter>[];
+    for (final f in model.fields) {
+      params.add(_modelFieldToParam(f));
     }
 
-    if (field.dbName != null) {
-      buf.writeln("    @JsonKey(name: '${field.dbName}')");
+    return Class((b) => b
+      ..name = model.name
+      ..annotations.add(refer('freezed'))
+      ..mixins.add(refer('_\$${model.name}'))
+      ..constructors.addAll([
+        Constructor((c) => c
+          ..factory = true
+          ..constant = true
+          ..redirect = refer('_${model.name}')
+          ..optionalParameters.addAll(params)),
+        Constructor((c) => c
+          ..factory = true
+          ..name = 'fromJson'
+          ..requiredParameters.add(Parameter((p) => p
+            ..name = 'json'
+            ..type = refer('Map<String, dynamic>')))
+          ..body = Code('return _\$${model.name}FromJson(json);')),
+      ]));
+  }
+
+  Parameter _modelFieldToParam(PrismaField f) {
+    if (f.isRelation) {
+      final type = f.isList ? 'List<${f.type}>' : f.type;
+      return Parameter((p) => p
+        ..name = f.name
+        ..named = true
+        ..annotations.add(CodeExpression(
+            Code("JsonKey(includeFromJson: false, includeToJson: false)")))
+        ..type = refer('$type?'));
     }
 
-    if (field.hasEmptyListDefault && field.isList) {
-      buf.writeln('    @Default(<${field.type}>[])');
-      buf.writeln('    List<${field.type}>? ${field.name},');
-      return buf.toString();
+    final annotations = <Expression>[];
+    if (f.dbName != null) {
+      annotations.add(CodeExpression(Code("JsonKey(name: '${f.dbName}')")));
     }
 
-    if (field.defaultValue != null && _isEnumType(field.type)) {
-      buf.writeln(
-          '    @Default(${field.type}.${toCamelCase(field.defaultValue!)})');
-      buf.writeln('    ${field.dartType} ${field.name},');
-      return buf.toString();
-    }
+    // Determine type and requiredness
+    final dartType = _toDartType(f.type);
+    String type;
+    bool isRequired = false;
 
-    final hasScalarDefault = field.defaultValue != null &&
-        !field.isRelation &&
-        !_isPrismaRuntimeDefault(field.defaultValue!);
-
-    if (hasScalarDefault) {
-      buf.writeln('    @Default(${field.defaultValue})');
-    }
-
-    final dartType = _toDartType(field.type);
-
-    if (hasScalarDefault) {
-      buf.writeln(field.isList
-          ? '    List<$dartType> ${field.name},'
-          : '    $dartType ${field.name},');
-    } else if (field.isRequired && !field.isList) {
-      buf.writeln('    required $dartType ${field.name},');
-    } else if (!field.isRequired && !field.isList) {
-      buf.writeln('    $dartType? ${field.name},');
-    } else if (field.isList && field.isRequired) {
-      buf.writeln('    required List<$dartType> ${field.name},');
+    if (f.hasEmptyListDefault && f.isList) {
+      annotations.add(CodeExpression(Code('Default(<${f.type}>[])')));
+      type = 'List<${f.type}>?';
+    } else if (f.defaultValue != null && _isEnumType(f.type)) {
+      annotations.add(CodeExpression(
+          Code('Default(${f.type}.${toCamelCase(f.defaultValue!)})')));
+      type = f.dartType;
     } else {
-      buf.writeln('    List<$dartType>? ${field.name},');
-    }
-
-    return buf.toString();
-  }
-
-  String _generateCreateInput(PrismaModel model) {
-    final buf = StringBuffer();
-    buf.writeln('/// Input for creating a new ${model.name}');
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class Create${model.name}Input with _\$Create${model.name}Input {');
-    buf.writeln('  const factory Create${model.name}Input({');
-
-    for (final field in model.fields) {
-      if (field.isId ||
-          field.isCreatedAt ||
-          field.isUpdatedAt ||
-          _isRelationField(field)) {
-        continue;
-      }
-      final dartType = _toDartType(field.type);
-
-      if (field.hasEmptyListDefault && field.isList) {
-        buf.writeln('    @Default(<$dartType>[])');
-        buf.writeln('    List<$dartType>? ${field.name},');
-        continue;
-      }
-
-      if (field.defaultValue != null && _isEnumType(field.type)) {
-        buf.writeln(
-            '    @Default($dartType.${toCamelCase(field.defaultValue!)})');
-        buf.writeln('    $dartType ${field.name},');
-        continue;
-      }
-
-      if (field.isRequired && field.defaultValue == null) {
-        buf.writeln(field.isList
-            ? '    required List<$dartType> ${field.name},'
-            : '    required $dartType ${field.name},');
-      } else if (field.defaultValue != null &&
-          !_isPrismaRuntimeDefault(field.defaultValue!)) {
-        buf.writeln('    @Default(${field.defaultValue})');
-        buf.writeln(field.isList
-            ? '    List<$dartType>? ${field.name},'
-            : '    $dartType? ${field.name},');
+      final hasScalarDefault = f.defaultValue != null &&
+          !f.isRelation &&
+          !_isPrismaRuntimeDefault(f.defaultValue!);
+      if (hasScalarDefault) {
+        annotations.add(CodeExpression(Code('Default(${f.defaultValue})')));
+        type = f.isList ? 'List<$dartType>' : dartType;
+      } else if (f.isRequired && !f.isList) {
+        type = dartType;
+        isRequired = true;
+      } else if (!f.isRequired && !f.isList) {
+        type = '$dartType?';
+      } else if (f.isList && f.isRequired) {
+        type = 'List<$dartType>';
+        isRequired = true;
       } else {
-        buf.writeln(field.isList
-            ? '    List<$dartType>? ${field.name},'
-            : '    $dartType? ${field.name},');
+        type = 'List<$dartType>?';
       }
     }
 
-    buf.writeln('  }) = _Create${model.name}Input;');
-    buf.writeln();
-    buf.writeln(
-        '  factory Create${model.name}Input.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$Create${model.name}InputFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
+    return Parameter((p) {
+      p
+        ..name = f.name
+        ..named = true
+        ..required = isRequired
+        ..type = refer(type)
+        ..annotations.addAll(annotations);
+    });
   }
 
-  String _generateUpdateInput(PrismaModel model) {
-    final buf = StringBuffer();
-    buf.writeln('/// Input for updating an existing ${model.name}');
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class Update${model.name}Input with _\$Update${model.name}Input {');
-    buf.writeln('  const factory Update${model.name}Input({');
+  // === CreateInput ===
 
-    for (final field in model.fields) {
-      if (field.isId ||
-          field.isCreatedAt ||
-          field.isUpdatedAt ||
-          _isRelationField(field)) {
+  Class _buildCreateInput(PrismaModel model) {
+    final params = <Parameter>[];
+    for (final f in model.fields) {
+      if (f.isId || f.isCreatedAt || f.isUpdatedAt || _isRelationField(f)) {
         continue;
       }
-      final dartType = _toDartType(field.type);
-      buf.writeln(field.isList
-          ? '    List<$dartType>? ${field.name},'
-          : '    $dartType? ${field.name},');
+      params.add(_createInputParam(f));
     }
 
-    buf.writeln('  }) = _Update${model.name}Input;');
-    buf.writeln();
-    buf.writeln(
-        '  factory Update${model.name}Input.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$Update${model.name}InputFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
+    return _freezedClass('Create${model.name}Input', params,
+        doc: '/// Input for creating a new ${model.name}');
   }
 
-  String _generateWhereUniqueInput(PrismaModel model) {
-    final uniqueFields = model.fields
-        .where((f) => (f.isId || f.isUnique) && !f.isRelation)
-        .toList();
-    if (uniqueFields.isEmpty) return '';
+  Parameter _createInputParam(PrismaField f) {
+    final dartType = _toDartType(f.type);
+    final annotations = <Expression>[];
+    String type;
+    bool isRequired = false;
 
-    final buf = StringBuffer();
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class ${model.name}WhereUniqueInput with _\$${model.name}WhereUniqueInput {');
-    buf.writeln('  const factory ${model.name}WhereUniqueInput({');
-    for (final field in uniqueFields) {
-      buf.writeln(field.isList
-          ? '    List<${field.type}>? ${field.name},'
-          : '    ${field.type}? ${field.name},');
+    if (f.hasEmptyListDefault && f.isList) {
+      annotations.add(CodeExpression(Code('Default(<$dartType>[])')));
+      type = 'List<$dartType>?';
+    } else if (f.defaultValue != null && _isEnumType(f.type)) {
+      annotations.add(CodeExpression(
+          Code('Default($dartType.${toCamelCase(f.defaultValue!)})')));
+      type = dartType;
+    } else if (f.isRequired && f.defaultValue == null) {
+      type = f.isList ? 'List<$dartType>' : dartType;
+      isRequired = true;
+    } else if (f.defaultValue != null &&
+        !_isPrismaRuntimeDefault(f.defaultValue!)) {
+      annotations.add(CodeExpression(Code('Default(${f.defaultValue})')));
+      type = f.isList ? 'List<$dartType>?' : '$dartType?';
+    } else {
+      type = f.isList ? 'List<$dartType>?' : '$dartType?';
     }
-    buf.writeln('  }) = _${model.name}WhereUniqueInput;');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}WhereUniqueInput.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}WhereUniqueInputFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
+
+    return Parameter((p) => p
+      ..name = f.name
+      ..named = true
+      ..required = isRequired
+      ..type = refer(type)
+      ..annotations.addAll(annotations));
   }
 
-  String _generateWhereInput(PrismaModel model) {
-    final buf = StringBuffer();
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class ${model.name}WhereInput with _\$${model.name}WhereInput {');
-    buf.writeln('  @JsonSerializable(explicitToJson: true)');
-    buf.writeln('  const factory ${model.name}WhereInput({');
+  // === UpdateInput ===
 
-    for (final field in model.fields) {
-      if (field.isRelation) {
-        final relType = field.isList
-            ? '${field.type}ListRelationFilter'
-            : '${field.type}RelationFilter';
-        buf.writeln('    $relType? ${field.name},');
+  Class _buildUpdateInput(PrismaModel model) {
+    final params = <Parameter>[];
+    for (final f in model.fields) {
+      if (f.isId || f.isCreatedAt || f.isUpdatedAt || _isRelationField(f)) {
         continue;
       }
-      final filterType = _getFilterType(field);
+      final dartType = _toDartType(f.type);
+      params.add(Parameter((p) => p
+        ..name = f.name
+        ..named = true
+        ..type = refer(f.isList ? 'List<$dartType>?' : '$dartType?')));
+    }
+
+    return _freezedClass('Update${model.name}Input', params,
+        doc: '/// Input for updating an existing ${model.name}');
+  }
+
+  // === WhereUniqueInput ===
+
+  List<Spec> _buildWhereUniqueInput(PrismaModel model) {
+    final uniqueFields =
+        model.fields.where((f) => (f.isId || f.isUnique) && !f.isRelation);
+    if (uniqueFields.isEmpty) return [];
+
+    final params = uniqueFields.map((f) => Parameter((p) => p
+      ..name = f.name
+      ..named = true
+      ..type = refer(f.isList ? 'List<${f.type}>?' : '${f.type}?')));
+
+    return [_freezedClass('${model.name}WhereUniqueInput', params.toList())];
+  }
+
+  // === WhereInput ===
+
+  Class _buildWhereInput(PrismaModel model) {
+    final params = <Parameter>[];
+
+    for (final f in model.fields) {
+      if (f.isRelation) {
+        final relType = f.isList
+            ? '${f.type}ListRelationFilter'
+            : '${f.type}RelationFilter';
+        params.add(Parameter((p) => p
+          ..name = f.name
+          ..named = true
+          ..type = refer('$relType?')));
+        continue;
+      }
+      final filterType = _getFilterType(f);
       if (filterType != null) {
-        buf.writeln('    $filterType? ${field.name},');
+        params.add(Parameter((p) => p
+          ..name = f.name
+          ..named = true
+          ..type = refer('$filterType?')));
       }
     }
 
-    buf.writeln('    List<${model.name}WhereInput>? AND,');
-    buf.writeln('    List<${model.name}WhereInput>? OR,');
-    buf.writeln('    ${model.name}WhereInput? NOT,');
-    buf.writeln('  }) = _${model.name}WhereInput;');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}WhereInput.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}WhereInputFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
+    // Logical operators
+    params.addAll([
+      Parameter((p) => p
+        ..name = 'AND'
+        ..named = true
+        ..type = refer('List<${model.name}WhereInput>?')),
+      Parameter((p) => p
+        ..name = 'OR'
+        ..named = true
+        ..type = refer('List<${model.name}WhereInput>?')),
+      Parameter((p) => p
+        ..name = 'NOT'
+        ..named = true
+        ..type = refer('${model.name}WhereInput?')),
+    ]);
+
+    final name = '${model.name}WhereInput';
+    return Class((b) => b
+      ..name = name
+      ..annotations.add(refer('freezed'))
+      ..mixins.add(refer('_\$$name'))
+      ..constructors.addAll([
+        Constructor((c) => c
+          ..factory = true
+          ..constant = true
+          ..redirect = refer('_$name')
+          ..annotations.add(
+              CodeExpression(Code('JsonSerializable(explicitToJson: true)')))
+          ..optionalParameters.addAll(params)),
+        Constructor((c) => c
+          ..factory = true
+          ..name = 'fromJson'
+          ..requiredParameters.add(Parameter((p) => p
+            ..name = 'json'
+            ..type = refer('Map<String, dynamic>')))
+          ..body = Code('return _\$${name}FromJson(json);')),
+      ]));
   }
 
-  String _generateRelationFilters(PrismaModel model) {
-    final buf = StringBuffer();
+  // === Relation filters ===
 
-    // ListRelationFilter
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class ${model.name}ListRelationFilter with _\$${model.name}ListRelationFilter {');
-    buf.writeln('  const factory ${model.name}ListRelationFilter({');
-    buf.writeln('    ${model.name}WhereInput? some,');
-    buf.writeln('    ${model.name}WhereInput? every,');
-    buf.writeln('    ${model.name}WhereInput? none,');
-    buf.writeln('  }) = _${model.name}ListRelationFilter;');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}ListRelationFilter.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}ListRelationFilterFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-
-    // RelationFilter
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class ${model.name}RelationFilter with _\$${model.name}RelationFilter {');
-    buf.writeln('  const factory ${model.name}RelationFilter({');
-    buf.writeln("    @JsonKey(name: 'is') ${model.name}WhereInput? is_,");
-    buf.writeln('    ${model.name}WhereInput? isNot,');
-    buf.writeln('  }) = _${model.name}RelationFilter;');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}RelationFilter.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}RelationFilterFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-
-    return buf.toString();
+  Class _buildListRelationFilter(PrismaModel model) {
+    final name = '${model.name}ListRelationFilter';
+    final wt = '${model.name}WhereInput?';
+    return _freezedClass(name, [
+      Parameter((p) => p
+        ..name = 'some'
+        ..named = true
+        ..type = refer(wt)),
+      Parameter((p) => p
+        ..name = 'every'
+        ..named = true
+        ..type = refer(wt)),
+      Parameter((p) => p
+        ..name = 'none'
+        ..named = true
+        ..type = refer(wt)),
+    ]);
   }
 
-  String _generateOrderByInput(PrismaModel model) {
-    final buf = StringBuffer();
-    buf.writeln('@freezed');
-    buf.writeln(
-        'class ${model.name}OrderByInput with _\$${model.name}OrderByInput {');
-    buf.writeln('  const factory ${model.name}OrderByInput({');
+  Class _buildRelationFilter(PrismaModel model) {
+    final name = '${model.name}RelationFilter';
+    final wt = '${model.name}WhereInput?';
+    return _freezedClass(name, [
+      Parameter((p) => p
+        ..name = 'is_'
+        ..named = true
+        ..annotations.add(CodeExpression(Code("JsonKey(name: 'is')")))
+        ..type = refer(wt)),
+      Parameter((p) => p
+        ..name = 'isNot'
+        ..named = true
+        ..type = refer(wt)),
+    ]);
+  }
 
-    for (final field in model.fields.where((f) =>
+  // === OrderByInput ===
+
+  Class _buildOrderByInput(PrismaModel model) {
+    final sortableFields = model.fields.where((f) =>
         !f.isRelation &&
         (f.type == 'String' ||
             f.type == 'Int' ||
@@ -331,34 +332,63 @@ class CbModelGenerator {
             f.type == 'DateTime' ||
             f.type == 'Boolean' ||
             f.isCreatedAt ||
-            f.isUpdatedAt))) {
-      buf.writeln('    SortOrder? ${field.name},');
-    }
+            f.isUpdatedAt));
 
-    buf.writeln('  }) = _${model.name}OrderByInput;');
-    buf.writeln();
-    buf.writeln(
-        '  factory ${model.name}OrderByInput.fromJson(Map<String, dynamic> json) =>');
-    buf.writeln('      _\$${model.name}OrderByInputFromJson(json);');
-    buf.writeln('}');
-    buf.writeln();
-    return buf.toString();
+    final params = sortableFields
+        .map((f) => Parameter((p) => p
+          ..name = f.name
+          ..named = true
+          ..type = refer('SortOrder?')))
+        .toList();
+
+    return _freezedClass('${model.name}OrderByInput', params);
   }
 
-  /// Generate enum class
+  // === Shared: build a @freezed class ===
+
+  Class _freezedClass(String name, List<Parameter> params, {String? doc}) {
+    return Class((b) {
+      if (doc != null) b.docs.add(doc);
+      b
+        ..name = name
+        ..annotations.add(refer('freezed'))
+        ..mixins.add(refer('_\$$name'))
+        ..constructors.addAll([
+          Constructor((c) => c
+            ..factory = true
+            ..constant = true
+            ..redirect = refer('_$name')
+            ..optionalParameters.addAll(params)),
+          Constructor((c) => c
+            ..factory = true
+            ..name = 'fromJson'
+            ..requiredParameters.add(Parameter((p) => p
+              ..name = 'json'
+              ..type = refer('Map<String, dynamic>')))
+            ..body = Code('return _\$${name}FromJson(json);')),
+        ]);
+    });
+  }
+
+  // === Enum generation ===
+
   String generateEnum(PrismaEnum enumDef) {
-    final buf = StringBuffer();
-    buf.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
-    buf.writeln();
-    buf.writeln('enum ${enumDef.name} {');
-    for (final value in enumDef.values) {
-      buf.writeln("  @JsonValue('$value')");
-      var dartValue = toCamelCase(value);
+    final values = enumDef.values.map((v) {
+      var dartValue = toCamelCase(v);
       if (_isDartReservedKeyword(dartValue)) dartValue = '${dartValue}Value';
-      buf.writeln('  $dartValue,');
-    }
-    buf.writeln('}');
-    return _formatter.format(buf.toString());
+      return EnumValue((ev) => ev
+        ..name = dartValue
+        ..annotations.add(CodeExpression(Code("JsonValue('$v')"))));
+    });
+
+    final lib = Library((b) => b
+      ..directives.add(Directive.import(
+          'package:freezed_annotation/freezed_annotation.dart'))
+      ..body.add(Enum((e) => e
+        ..name = enumDef.name
+        ..values.addAll(values))));
+
+    return _formatter.format('${lib.accept(_emitter)}');
   }
 
   /// Generate all model files.
@@ -373,11 +403,10 @@ class CbModelGenerator {
     return files;
   }
 
-  // === Helper methods (same logic as original) ===
+  // === Helpers ===
 
   bool _isEnumType(String t) => schema.enums.any((e) => e.name == t);
   bool _isModelType(String t) => schema.models.any((m) => m.name == t);
-
   bool _isRelationField(PrismaField f) => f.isRelation || _isModelType(f.type);
 
   bool _isPrimitiveType(String t) => const {
@@ -411,21 +440,21 @@ class CbModelGenerator {
         _ => t,
       };
 
-  String? _getFilterType(PrismaField field) {
-    if (field.isList) {
-      return switch (field.type) {
+  String? _getFilterType(PrismaField f) {
+    if (f.isList) {
+      return switch (f.type) {
         'String' => 'StringListFilter',
         'Int' => 'IntListFilter',
         _ => null,
       };
     }
-    return switch (field.type) {
+    return switch (f.type) {
       'String' => 'StringFilter',
       'Int' => 'IntFilter',
       'Float' || 'Decimal' => 'FloatFilter',
       'Boolean' => 'BooleanFilter',
       'DateTime' => 'DateTimeFilter',
-      _ => _isEnumType(field.type) ? '${field.type}Filter' : null,
+      _ => _isEnumType(f.type) ? '${f.type}Filter' : null,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues
@@ -40,7 +40,7 @@ dev_dependencies:
   flutter_lints: ^3.0.0
   flutter_test:
     sdk: flutter
-  freezed: ^3.0.6
+  freezed: ">=3.0.6 <3.2.0"
   json_serializable: ^6.8.0
   test: ^1.25.0
 


### PR DESCRIPTION
## Summary

Completes the architecture migration: **0 `buf.write` calls** across all 5 generators.

| Version | buf.write calls | Generators on code_builder |
|---------|----------------|---------------------------|
| v0.4.0 | 917 | 0/6 |
| v0.5.0 | 167 | 3/5 (delegate, client, schema_registry) |
| **v0.5.1** | **0** | **5/5** |

### Changes
- `cb_model_generator.dart`: Rewritten with code_builder `Class`/`Constructor`/`Parameter` builders. Freezed classes (`@freezed`, `with _$Model`, `= _Model`, `fromJson`) all generated via AST.
- `cb_filter_types_generator.dart`: Rewritten with code_builder `Class`/`Enum`/`EnumValue` builders. `@JsonKey(name: 'in')` handled via `CodeExpression`.
- Freezed dev dependency constrained to `>=3.0.6 <3.2.0` (3.2.x needs Dart SDK >=3.7.0)

### Integration Test
Tested with familiarise_mobile backend (dart_frog + curl):
- POST /api/feedback: PASS (UUID auto-gen)
- GET /api/feedback: PASS (9 items)
- GET /api/consultants: PASS (nested includes + computed fields)

## Test plan
- [x] All unit tests pass
- [x] `flutter analyze --fatal-infos` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero changes
- [x] Generated code identical quality to v0.5.0
- [x] Integration-tested with live Supabase DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)