### PR TITLE
fix: v0.5.3 — PR review fixes (orderBy consistency, redundant casts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-03-28
+
+### Fixed
+- Remove redundant `as` casts after `is` type checks in findMany/findManyRaw orderBy handling
+- Add missing `List` orderBy support in `findFirstRaw` (consistent with findManyRaw)
+
 ## [0.5.2] - 2026-03-28
 
 ### Added

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -201,9 +201,9 @@ class CbDelegateGenerator {
           .action(QueryAction.findMany);
 
       if (where != null) queryBuilder.where(_whereToJson(where));
-      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy as Map<String, dynamic>);
+      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy);
       if (orderBy is List) queryBuilder.orderBy(orderBy);
-      if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy as ${m}OrderByInput));
+      if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy));
       if (take != null) queryBuilder.take(take);
       if (skip != null) queryBuilder.skip(skip);
       if (include != null) queryBuilder.include(include);
@@ -269,7 +269,7 @@ class CbDelegateGenerator {
           .action(QueryAction.findMany);
 
       if (where != null) queryBuilder.where(where);
-      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy as Map<String, dynamic>);
+      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy);
       if (orderBy is List) queryBuilder.orderBy(orderBy);
       if (take != null) queryBuilder.take(take);
       if (skip != null) queryBuilder.skip(skip);
@@ -307,7 +307,8 @@ class CbDelegateGenerator {
           .action(QueryAction.findFirst);
 
       if (where != null) queryBuilder.where(where);
-      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy as Map<String, dynamic>);
+      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy);
+      if (orderBy is List) queryBuilder.orderBy(orderBy);
       if (include != null) queryBuilder.include(include);
 
       return await _executor.executeQueryAsSingleMap(queryBuilder.build());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues


### PR DESCRIPTION
## Summary

Addresses 3 review comments from PR #39:

1. **HIGH**: `findFirstRaw` now supports `List` orderBy for multi-column sorting (was `Map`-only, inconsistent with `findManyRaw`)
2. **MEDIUM**: Removed redundant `as Map<String, dynamic>` casts in `findMany` orderBy (Dart type promotion handles it)
3. **MEDIUM**: Removed redundant `as Map<String, dynamic>` cast in `findManyRaw` orderBy

## Test plan
- [x] All unit tests pass
- [x] `flutter analyze --fatal-infos` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)