### PR TITLE
fix: v0.5.5 — parser brace-counting, implicit relations, FK ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-04-04
+
+### Fixed
+
+#### Parser: Brace-counting for model body extraction
+- **Fixed inline comments with `{` or `}` truncating model parsing** — e.g., `preferences Json? // e.g., { preferredDates: [] }` caused everything after the `}` in the comment to be lost (userId, webinarId, classId fields dropped from Waitlist model)
+- Replaced `[^}]+` regex with brace-counting `_extractBlocks()` method for both model and enum parsing
+
+#### Parser: Implicit relation detection
+- **Fixed fields referencing other models not being marked as relations** when they lack an explicit `@relation` attribute (e.g., `subDomains SubDomain[]` on Domain)
+- Parser now checks if `fieldType` is a known model name in addition to checking for `@relation`
+
+#### Schema Registry: Correct FK for multi-relation models
+- **Fixed wrong foreign key when a model has multiple relations to the same target** (e.g., ModerationReport has both `reportedBy` and `targetUser` pointing to User)
+- Now uses the field's own `@relation(fields: [...])` first instead of picking the first matching relation on the model
+
 ## [0.5.4] - 2026-03-28
 
 ### Fixed

--- a/lib/src/generator/cb_schema_registry_generator.dart
+++ b/lib/src/generator/cb_schema_registry_generator.dart
@@ -128,8 +128,9 @@ class CbSchemaRegistryGenerator {
           ));
         }
       } else {
-        final fk = _findForeignKeyOnModel(model, target) ??
-            _findForeignKeyFromField(field);
+        // Use this field's own @relation(fields: [...]) first, then fall back to convention
+        final fk = _findForeignKeyFromField(field) ??
+            _findForeignKeyOnModel(model, target);
         if (fk == null) continue;
 
         final backRef = targetModel.fields

--- a/lib/src/generator/prisma_parser.dart
+++ b/lib/src/generator/prisma_parser.dart
@@ -422,11 +422,11 @@ class PrismaParser {
       datasourceProvider = datasourceMatch.group(1)!;
     }
 
-    // Extract enums
-    final enumPattern = RegExp(r'enum\s+(\w+)\s*\{([^}]+)\}', multiLine: true);
-    for (final match in enumPattern.allMatches(schemaContent)) {
-      final name = match.group(1)!;
-      final body = match.group(2)!;
+    // Extract enums (use brace-counting to handle comments with braces)
+    final enumBlocks = _extractBlocks(schemaContent, 'enum');
+    for (final block in enumBlocks) {
+      final name = block.name;
+      final body = block.body;
       final values = body
           .split('\n')
           .map((line) {
@@ -447,18 +447,16 @@ class PrismaParser {
     final modelNameMap = <String, String>{}; // originalName -> dartName
 
     // First pass: collect all model name mappings
-    final modelPattern =
-        RegExp(r'model\s+(\w+)\s*\{([^}]+)\}', multiLine: true);
-    for (final match in modelPattern.allMatches(schemaContent)) {
-      final originalModelName = match.group(1)!;
-      final modelResult = _handleReservedKeyword(originalModelName, 'model');
-      modelNameMap[originalModelName] = modelResult.dartName;
+    final modelBlocks = _extractBlocks(schemaContent, 'model');
+    for (final block in modelBlocks) {
+      final modelResult = _handleReservedKeyword(block.name, 'model');
+      modelNameMap[block.name] = modelResult.dartName;
     }
 
     // Second pass: parse models with resolved type names
-    for (final match in modelPattern.allMatches(schemaContent)) {
-      final originalModelName = match.group(1)!;
-      final modelBody = match.group(2)!;
+    for (final block in modelBlocks) {
+      final originalModelName = block.name;
+      final modelBody = block.body;
 
       // Handle reserved keywords - auto-rename if needed
       final modelResult = _handleReservedKeyword(originalModelName, 'model');
@@ -527,8 +525,11 @@ class PrismaParser {
             }
           }
 
-          // Check if it's a relation
-          final isRelation = attributes.contains('@relation');
+          // Check if it's a relation — explicit (@relation) or implicit (type is a model)
+          final baseFieldType =
+              fieldType.replaceAll('?', '').replaceAll('[]', '');
+          final isRelation = attributes.contains('@relation') ||
+              modelNameMap.containsKey(baseFieldType);
           String? relationName;
           List<String>? relationFromFields;
           List<String>? relationToFields;
@@ -637,6 +638,29 @@ class PrismaParser {
     );
   }
 
+  /// Extract model/enum blocks using brace counting instead of [^}] regex.
+  ///
+  /// Handles inline comments containing `{` or `}` which break simple regex.
+  List<_Block> _extractBlocks(String content, String keyword) {
+    final blocks = <_Block>[];
+    final pattern = RegExp('$keyword\\s+(\\w+)\\s*\\{');
+    for (final match in pattern.allMatches(content)) {
+      final name = match.group(1)!;
+      final start = match.end; // position after the opening {
+      var depth = 1;
+      var i = start;
+      while (i < content.length && depth > 0) {
+        final ch = content[i];
+        if (ch == '{') depth++;
+        if (ch == '}') depth--;
+        i++;
+      }
+      // i is now past the closing }, body is between start and i-1
+      blocks.add(_Block(name: name, body: content.substring(start, i - 1)));
+    }
+    return blocks;
+  }
+
   /// Extracts content inside @default(...) handling nested parentheses.
   ///
   /// For example:
@@ -669,4 +693,11 @@ class PrismaParser {
     // Content is from contentStart to i-1 (excluding closing paren)
     return attributes.substring(contentStart, i - 1);
   }
+}
+
+/// A named block extracted from a Prisma schema (model or enum).
+class _Block {
+  final String name;
+  final String body;
+  const _Block({required this.name, required this.body});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.5.4
+version: 0.5.5
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues


### PR DESCRIPTION
## Summary

Fixes 3 critical parser/generator bugs found during schema verification.

### Bug 1: Inline comments with `{`/`}` truncate model parsing
- `preferences Json? // e.g., { preferredDates: [], maxPrice: 500 }` — the `}` in the comment closed the regex match
- **Fix:** Replaced `[^}]+` regex with brace-counting `_extractBlocks()` for both model and enum parsing
- **Impact:** Waitlist model was missing `userId`, `webinarId`, `classId` fields

### Bug 2: Implicit relations not detected
- Fields like `subDomains SubDomain[]` (no `@relation` attribute) were parsed as non-relation fields
- **Fix:** Parser now checks if `fieldType` is a known model name in addition to `@relation`
- **Impact:** Domain model was missing all 3 relations in schema_registry

### Bug 3: Wrong FK for multi-relation models
- ModerationReport has `reportedBy→User` and `targetUser→User`. Generator picked first match's FK for both.
- **Fix:** Use field's own `@relation(fields:[...])` before convention-based lookup
- **Impact:** `targetUser` FK was `reportedById` instead of `targetUserId`

## Test plan
- [x] All unit tests pass
- [x] `flutter analyze --fatal-infos` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero changes
- [x] Integration tested with familiarise_mobile (local path, dart_frog + curl)
- [x] Verified: Waitlist now has userId/webinarId/classId
- [x] Verified: Domain has correct oneToMany relations
- [x] Verified: ModerationReport.targetUser uses targetUserId FK

🤖 Generated with [Claude Code](https://claude.com/claude-code)