### PR TITLE
feat: v0.7.0 — the complete ORM (transactions, upsert, aggregate, nested writes, include hydration, filters, pooling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,97 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-02
+
+The **complete-ORM** release: the typed `PrismaClient` surface now covers
+transactions, upsert, aggregate, nested writes, typed include-hydration,
+cursor pagination, JSON/scalar-list/BigInt/Bytes filters, connection pooling,
+and composite-key addressing — retiring the need for hand-built
+`JsonQueryBuilder`/raw queries in application code.
+
+### Added
+
+#### Transactions (#68)
+- **`$transaction((tx) async { ... })`** runs through a polymorphic
+  `runTransaction` on the executor. Nested `$transaction` calls flatten onto
+  the ambient transaction instead of crashing (`_executor as QueryExecutor`
+  no longer throws inside a tx). `$disconnect()` now routes through
+  `dispose()`.
+
+#### Upsert (#66)
+- **`upsert({where, create, update})`** delegate over the existing
+  `INSERT ... ON CONFLICT` compiler. `WhereUniqueInput` → conflict columns
+  (with `@map` resolution); `@default(uuid/cuid/now)` and `@updatedAt` are
+  autofilled on the create arm and `@updatedAt` refreshed on the update arm.
+  Guarded on models with a unique key (including composite).
+
+#### Aggregate (#65)
+- **`aggregate()`** delegate (`_count`/`_avg`/`_sum`/`_min`/`_max`, `HAVING`)
+  with `@map`-resolved aggregate arguments, plus the previously-missing
+  **`findFirstOrThrow`** delegate.
+
+#### Composite unique / `@@id` / `@@unique` addressing (#C6)
+- Generated **compound `WhereUniqueInput`** classes let
+  `findUnique`/`update`/`delete`/`upsert` target composite keys. The compound
+  `toJson` flattens into individual field equalities, so the compiler needs no
+  compound-key awareness and upsert gets the correct multi-column
+  `ON CONFLICT`.
+
+#### Typed include + relation hydration (#67)
+- **`fromJson` hydrates nested relations** into typed models (to-one →
+  `Related?`, to-many → `List<Related>`), and generated **`XInclude`** classes
+  give `findMany/findFirst/findUnique/findFirstOrThrow` a typed `include:`
+  argument — retiring `findManyRaw`/`findFirstRaw` for typed results.
+
+#### Full nested writes (#64)
+- Create/Update inputs carry an optional **`<Model><Relation>WriteInput`** per
+  relation (`connect`/`disconnect`/`create`). Delegate `create`/`update`
+  detect relation ops and route to an atomic relations engine; relation
+  mutations resolve the parent PK from the main mutation's `RETURNING` row
+  (fixes DB-generated-uuid parents). To-one `connect` inlines the FK; to-many
+  `create` emits child INSERTs. A belongsTo `create` throws `UnsupportedError`
+  (parent-first ordering unsupported — create the parent + `connect`).
+
+#### Filters (#69)
+- **Cursor pagination**: `JsonQueryBuilder.cursor()` + typed delegate `cursor:`
+  param derive a canonical keyset predicate from the cursor value and
+  `orderBy` (inclusive of the cursor row; pair with `skip:1`).
+- **Scalar-list (array) filters**: `has`/`hasSome`/`hasEvery`/`isEmpty`
+  (`= ANY`/`&&`/`@>`/`cardinality`).
+- **JSON(B) filters** (PostgreSQL/Supabase): `path` addressing via `#>`/`#>>`
+  with `equals`(`::jsonb`), `string_contains`/`_starts_with`/`_ends_with`
+  (`LIKE`), `array_contains` (`@>`), numeric `lt`/`lte`/`gt`/`gte`.
+- **`BigIntFilter` + `BytesFilter`**; BigInt/Bytes columns map to them.
+
+#### Connection pooling (#70)
+- **`PostgresAdapter.pooled(pg.Pool)`** runs non-transactional statements on
+  connections borrowed from the pool; each transaction pins a dedicated pool
+  connection for its lifetime (via `withConnection` + a release completer) so
+  all statements share one physical connection. `dispose()` closes the pool.
+
+#### Other ORM gaps
+- **Atomic numeric updates**: `{increment/decrement/multiply/divide/set: n}`
+  compile to `col = col ± ?` (applies to `update` and `updateMany`).
+- **`createManyAndReturn`** (`INSERT ... RETURNING *`, typed rows) and
+  **`skipDuplicates`** (`ON CONFLICT DO NOTHING`) on `createMany`.
+- **Nested-include depth guard**: recursion capped at `maxIncludeDepth` (5),
+  throwing on pathological/cyclic include graphs.
+
+### Fixed
+- **`@map` resolution in write paths** (#C3): upsert conflict columns, groupBy
+  `by`/aggregate fields, and many-to-many connect/disconnect + `EXISTS`
+  subqueries now resolve Dart field names to DB columns via the registry.
+- **To-one relation filters** (#C2): `is`/`isNot` in `where` now compile
+  (EXISTS / NOT EXISTS with null-target semantics) instead of throwing;
+  `is`/`isNot` on a to-many relation is rejected.
+
+### Notes
+- Batch `$transaction([...])` (array form) is intentionally **not** provided:
+  delegate methods execute eagerly (no lazy promises), so the callback form
+  `$transaction((tx) async { ... })` is the supported API.
+- Soft-delete stays a documented `deletedAt: null` filter pattern; full
+  `$extends` middleware remains out of scope.
+
 ## [0.6.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,18 @@ and composite-key addressing — retiring the need for hand-built
   (`LIKE`), `array_contains` (`@>`), numeric `lt`/`lte`/`gt`/`gte`.
 - **`BigIntFilter` + `BytesFilter`**; BigInt/Bytes columns map to them.
 
+#### Sentry error reporting (bundled)
+- **`SentryQueryLogger`** (a `QueryLogger`) forwards failed queries to Sentry
+  via `captureException` with SQL/operation/model context — a no-op unless the
+  host app has already initialized Sentry (`Sentry.isEnabled`), so it's always
+  safe to include. Plug it into the executor's `logger` (compose with
+  `ConsoleQueryLogger` via `CompositeQueryLogger`).
+- **`PrismaSentry.init(...)`** convenience for standalone/tooling use that owns
+  Sentry itself (DSN via arg or the `SENTRY_DSN` dart-define). Apps that already
+  call `Sentry.init`/`SentryFlutter.init` should skip this and just add the
+  logger. New dependency: `sentry: ">=8.0.0 <10.0.0"` (wide range so sentry
+  8.x and 9.x consumers both resolve).
+
 #### Connection pooling (#70)
 - **`PostgresAdapter.pooled(pg.Pool)`** runs non-transactional statements on
   connections borrowed from the pool; each transaction pins a dedicated pool

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -104,3 +104,4 @@ export 'src/runtime/errors/prisma_exceptions.dart';
 
 // Query logging (debugging and monitoring)
 export 'src/runtime/logging/query_logger.dart';
+export 'src/runtime/logging/sentry_query_logger.dart';

--- a/lib/runtime_server.dart
+++ b/lib/runtime_server.dart
@@ -103,3 +103,4 @@ export 'src/runtime/errors/prisma_exceptions.dart';
 
 // Query logging (debugging and monitoring)
 export 'src/runtime/logging/query_logger.dart';
+export 'src/runtime/logging/sentry_query_logger.dart';

--- a/lib/src/generator/cb_client_generator.dart
+++ b/lib/src/generator/cb_client_generator.dart
@@ -135,8 +135,7 @@ class CbClientGenerator {
             ..named = true
             ..type = refer('IsolationLevel?')))
           ..body = Code('''
-            final queryExecutor = _executor as QueryExecutor;
-            return await queryExecutor.executeInTransaction((txExecutor) async {
+            return await _executor.runTransaction((txExecutor) async {
               final txClient = PrismaClient._transaction(txExecutor);
               return await callback(txClient);
             }, isolationLevel: isolationLevel);
@@ -148,8 +147,7 @@ class CbClientGenerator {
           ..modifier = MethodModifier.async
           ..returns = refer('Future<void>')
           ..body = Code('''
-            final queryExecutor = _executor as QueryExecutor;
-            await queryExecutor.dispose();
+            await _executor.dispose();
           ''')),
       ]));
   }

--- a/lib/src/generator/cb_client_generator.dart
+++ b/lib/src/generator/cb_client_generator.dart
@@ -23,14 +23,11 @@ class CbClientGenerator {
       Directive.import('package:prisma_flutter_connector/$runtimeImport'),
     ];
 
-    // Import delegates and models
+    // The client class exposes delegates only; model types never appear in its
+    // surface, so it imports delegates but not model files.
     for (final model in schema.models) {
       final sn = toSnakeCase(model.name);
       directives.add(Directive.import('delegates/${sn}_delegate.dart'));
-    }
-    for (final model in schema.models) {
-      final sn = toSnakeCase(model.name);
-      directives.add(Directive.import('models/$sn.dart'));
     }
 
     final library = Library((b) => b

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -33,7 +33,8 @@ class CbDelegateGenerator {
       ])
       ..body.add(_buildDelegateClass(modelName, tableName,
           hasUniqueFields: model.fields
-              .any((f) => (f.isId || f.isUnique) && !f.isRelation))));
+                  .any((f) => (f.isId || f.isUnique) && !f.isRelation) ||
+              model.compositeUniques.isNotEmpty)));
 
     final emitter = DartEmitter(useNullSafetySyntax: true);
     return _formatter.format('${library.accept(emitter)}');

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -97,7 +97,7 @@ class CbDelegateGenerator {
       Parameter((p) => p
         ..name = 'include'
         ..named = true
-        ..type = refer('Map<String, dynamic>?')),
+        ..type = refer('${m}Include?')),
     ])
     ..body = Code('''
       final queryBuilder = JsonQueryBuilder()
@@ -105,7 +105,7 @@ class CbDelegateGenerator {
           .action(QueryAction.findUnique)
           .where(_whereUniqueToJson(where));
 
-      if (include != null) queryBuilder.include(include);
+      if (include != null) queryBuilder.include(include.toJson());
 
       final result = await _executor.executeQueryAsSingleMap(queryBuilder.build());
       return result != null ? $m.fromJson(_normalizeForJson(result)) : null;
@@ -146,7 +146,7 @@ class CbDelegateGenerator {
       Parameter((p) => p
         ..name = 'include'
         ..named = true
-        ..type = refer('Map<String, dynamic>?')),
+        ..type = refer('${m}Include?')),
     ])
     ..body = Code('''
       final queryBuilder = JsonQueryBuilder()
@@ -155,7 +155,7 @@ class CbDelegateGenerator {
 
       if (where != null) queryBuilder.where(_whereToJson(where));
       if (orderBy != null) queryBuilder.orderBy(_orderByToJson(orderBy));
-      if (include != null) queryBuilder.include(include);
+      if (include != null) queryBuilder.include(include.toJson());
 
       final result = await _executor.executeQueryAsSingleMap(queryBuilder.build());
       return result != null ? $m.fromJson(_normalizeForJson(result)) : null;
@@ -178,7 +178,7 @@ class CbDelegateGenerator {
       Parameter((p) => p
         ..name = 'include'
         ..named = true
-        ..type = refer('Map<String, dynamic>?')),
+        ..type = refer('${m}Include?')),
     ])
     ..body = Code('''
       final result =
@@ -214,7 +214,7 @@ class CbDelegateGenerator {
       Parameter((p) => p
         ..name = 'include'
         ..named = true
-        ..type = refer('Map<String, dynamic>?')),
+        ..type = refer('${m}Include?')),
       Parameter((p) => p
         ..name = 'includeRequired'
         ..named = true
@@ -243,7 +243,7 @@ class CbDelegateGenerator {
       if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy));
       if (take != null) queryBuilder.take(take);
       if (skip != null) queryBuilder.skip(skip);
-      if (include != null) queryBuilder.include(include);
+      if (include != null) queryBuilder.include(include.toJson());
       if (includeRequired != null) queryBuilder.includeRequired(includeRequired);
       if (selectFields != null) queryBuilder.selectFields(selectFields);
       if (distinct == true) queryBuilder.distinct(distinctFields);

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -67,6 +67,7 @@ class CbDelegateGenerator {
         _create(modelName, tableName),
         _createMany(modelName, tableName),
         if (hasUniqueFields) _update(modelName, tableName),
+        if (hasUniqueFields) _upsert(modelName, tableName),
         _updateMany(modelName, tableName),
         if (hasUniqueFields) _delete(modelName, tableName),
         _deleteMany(modelName, tableName),
@@ -392,6 +393,43 @@ class CbDelegateGenerator {
 
       // Fetch the updated record
       return await findUniqueOrThrow(where: where);
+    '''));
+
+  Method _upsert(String m, String t) => Method((b) => b
+    ..name = 'upsert'
+    ..docs.add('/// Create a $m, or update it if the unique key already exists')
+    ..modifier = MethodModifier.async
+    ..returns = refer('Future<$m>')
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'where'
+        ..named = true
+        ..required = true
+        ..type = refer('${m}WhereUniqueInput')),
+      Parameter((p) => p
+        ..name = 'create'
+        ..named = true
+        ..required = true
+        ..type = refer('Create${m}Input')),
+      Parameter((p) => p
+        ..name = 'update'
+        ..named = true
+        ..required = true
+        ..type = refer('Update${m}Input')),
+    ])
+    ..body = Code('''
+      final query = JsonQueryBuilder()
+          .model('$t')
+          .action(QueryAction.upsert)
+          .where(_whereUniqueToJson(where))
+          .data({'create': create.toJson(), 'update': update.toJson()})
+          .build();
+
+      final result = await _executor.executeQueryAsSingleMap(query);
+      if (result == null) {
+        throw Exception('Failed to upsert $m');
+      }
+      return $m.fromJson(_normalizeForJson(result));
     '''));
 
   Method _updateMany(String m, String t) => Method((b) => b

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -75,6 +75,7 @@ class CbDelegateGenerator {
         _findFirstRaw(modelName, tableName),
         _create(modelName, tableName, relLiteral),
         _createMany(modelName, tableName),
+        _createManyAndReturn(modelName, tableName),
         if (hasUniqueFields) _update(modelName, tableName, relLiteral),
         if (hasUniqueFields) _upsert(modelName, tableName),
         _updateMany(modelName, tableName),
@@ -403,19 +404,52 @@ class CbDelegateGenerator {
     ..docs.add('/// Create multiple ${m}s')
     ..modifier = MethodModifier.async
     ..returns = refer('Future<int>')
-    ..optionalParameters.add(Parameter((p) => p
-      ..name = 'data'
-      ..named = true
-      ..required = true
-      ..type = refer('List<Create${m}Input>')))
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'data'
+        ..named = true
+        ..required = true
+        ..type = refer('List<Create${m}Input>')),
+      Parameter((p) => p
+        ..name = 'skipDuplicates'
+        ..named = true
+        ..type = refer('bool?')),
+    ])
     ..body = Code('''
-      final query = JsonQueryBuilder()
+      final queryBuilder = JsonQueryBuilder()
           .model('$t')
           .action(QueryAction.createMany)
-          .data({'data': data.map((d) => d.toJson()).toList()})
-          .build();
+          .data({'data': data.map((d) => d.toJson()).toList()});
+      if (skipDuplicates == true) queryBuilder.skipDuplicates();
 
-      return await _executor.executeMutation(query);
+      return await _executor.executeMutation(queryBuilder.build());
+    '''));
+
+  Method _createManyAndReturn(String m, String t) => Method((b) => b
+    ..name = 'createManyAndReturn'
+    ..docs.add('/// Create multiple ${m}s and return the created rows')
+    ..modifier = MethodModifier.async
+    ..returns = refer('Future<List<$m>>')
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'data'
+        ..named = true
+        ..required = true
+        ..type = refer('List<Create${m}Input>')),
+      Parameter((p) => p
+        ..name = 'skipDuplicates'
+        ..named = true
+        ..type = refer('bool?')),
+    ])
+    ..body = Code('''
+      final queryBuilder = JsonQueryBuilder()
+          .model('$t')
+          .action(QueryAction.createManyAndReturn)
+          .data({'data': data.map((d) => d.toJson()).toList()});
+      if (skipDuplicates == true) queryBuilder.skipDuplicates();
+
+      final results = await _executor.executeQueryAsMaps(queryBuilder.build());
+      return results.map((json) => $m.fromJson(_normalizeForJson(json))).toList();
     '''));
 
   Method _update(String m, String t, String relLiteral) => Method((b) => b

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -34,14 +34,21 @@ class CbDelegateGenerator {
       ..body.add(_buildDelegateClass(modelName, tableName,
           hasUniqueFields: model.fields
                   .any((f) => (f.isId || f.isUnique) && !f.isRelation) ||
-              model.compositeUniques.isNotEmpty)));
+              model.compositeUniques.isNotEmpty,
+          relationFields: model.fields
+              .where((f) => f.isRelation)
+              .map((f) => f.name)
+              .toList())));
 
     final emitter = DartEmitter(useNullSafetySyntax: true);
     return _formatter.format('${library.accept(emitter)}');
   }
 
   Class _buildDelegateClass(String modelName, String tableName,
-      {required bool hasUniqueFields}) {
+      {required bool hasUniqueFields, required List<String> relationFields}) {
+    final relLiteral = relationFields.isEmpty
+        ? 'const <String>{}'
+        : '{${relationFields.map((n) => "'$n'").join(', ')}}';
     return Class((b) => b
       ..name = '${modelName}Delegate'
       ..docs.addAll([
@@ -66,9 +73,9 @@ class CbDelegateGenerator {
         _findMany(modelName, tableName),
         _findManyRaw(modelName, tableName),
         _findFirstRaw(modelName, tableName),
-        _create(modelName, tableName),
+        _create(modelName, tableName, relLiteral),
         _createMany(modelName, tableName),
-        if (hasUniqueFields) _update(modelName, tableName),
+        if (hasUniqueFields) _update(modelName, tableName, relLiteral),
         if (hasUniqueFields) _upsert(modelName, tableName),
         _updateMany(modelName, tableName),
         if (hasUniqueFields) _delete(modelName, tableName),
@@ -351,7 +358,7 @@ class CbDelegateGenerator {
       return await _executor.executeQueryAsSingleMap(queryBuilder.build());
     '''));
 
-  Method _create(String m, String t) => Method((b) => b
+  Method _create(String m, String t, String relLiteral) => Method((b) => b
     ..name = 'create'
     ..docs.add('/// Create a new $m')
     ..modifier = MethodModifier.async
@@ -362,11 +369,21 @@ class CbDelegateGenerator {
       ..required = true
       ..type = refer('Create${m}Input')))
     ..body = Code('''
+      final data0 = data.toJson();
       final query = JsonQueryBuilder()
           .model('$t')
           .action(QueryAction.create)
-          .data(data.toJson())
+          .data(data0)
           .build();
+
+      const relationFields = $relLiteral;
+      if (data0.keys.any(relationFields.contains)) {
+        final row = await _executor.executeMutationWithRelationsReturning(query);
+        if (row == null) {
+          throw Exception('Failed to create $m');
+        }
+        return $m.fromJson(_normalizeForJson(row));
+      }
 
       final result = await _executor.executeQueryAsSingleMap(query);
       if (result == null) {
@@ -395,7 +412,7 @@ class CbDelegateGenerator {
       return await _executor.executeMutation(query);
     '''));
 
-  Method _update(String m, String t) => Method((b) => b
+  Method _update(String m, String t, String relLiteral) => Method((b) => b
     ..name = 'update'
     ..docs.add('/// Update a $m')
     ..modifier = MethodModifier.async
@@ -413,14 +430,20 @@ class CbDelegateGenerator {
         ..type = refer('Update${m}Input')),
     ])
     ..body = Code('''
+      final data0 = data.toJson();
       final query = JsonQueryBuilder()
           .model('$t')
           .action(QueryAction.update)
           .where(_whereUniqueToJson(where))
-          .data(data.toJson())
+          .data(data0)
           .build();
 
-      await _executor.executeMutation(query);
+      const relationFields = $relLiteral;
+      if (data0.keys.any(relationFields.contains)) {
+        await _executor.executeMutationWithRelationsReturning(query);
+      } else {
+        await _executor.executeMutation(query);
+      }
 
       // Fetch the updated record
       return await findUniqueOrThrow(where: where);

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -70,7 +70,7 @@ class CbDelegateGenerator {
         if (hasUniqueFields) _findUniqueOrThrow(modelName),
         _findFirst(modelName, tableName),
         _findFirstOrThrow(modelName),
-        _findMany(modelName, tableName),
+        _findMany(modelName, tableName, hasUniqueFields),
         _findManyRaw(modelName, tableName),
         _findFirstRaw(modelName, tableName),
         _create(modelName, tableName, relLiteral),
@@ -196,7 +196,7 @@ class CbDelegateGenerator {
       return result;
     '''));
 
-  Method _findMany(String m, String t) => Method((b) => b
+  Method _findMany(String m, String t, bool hasUniqueFields) => Method((b) => b
     ..name = 'findMany'
     ..docs.add('/// Find multiple ${m}s with optional filters')
     ..modifier = MethodModifier.async
@@ -238,6 +238,11 @@ class CbDelegateGenerator {
         ..name = 'distinctFields'
         ..named = true
         ..type = refer('List<String>?')),
+      if (hasUniqueFields)
+        Parameter((p) => p
+          ..name = 'cursor'
+          ..named = true
+          ..type = refer('${m}WhereUniqueInput?')),
     ])
     ..body = Code('''
       final queryBuilder = JsonQueryBuilder()
@@ -250,6 +255,7 @@ class CbDelegateGenerator {
       if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy));
       if (take != null) queryBuilder.take(take);
       if (skip != null) queryBuilder.skip(skip);
+      ${hasUniqueFields ? 'if (cursor != null) queryBuilder.cursor(_whereUniqueToJson(cursor));' : ''}
       if (include != null) queryBuilder.include(include.toJson());
       if (includeRequired != null) queryBuilder.includeRequired(includeRequired);
       if (selectFields != null) queryBuilder.selectFields(selectFields);

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -29,7 +29,6 @@ class CbDelegateGenerator {
       ..directives.addAll([
         Directive.import('package:prisma_flutter_connector/$runtimeImport'),
         Directive.import('../models/${toSnakeCase(modelName)}.dart'),
-        Directive.import('../filters.dart'),
       ])
       ..body.add(_buildDelegateClass(modelName, tableName,
           hasUniqueFields: model.fields
@@ -813,7 +812,7 @@ class CbDelegateGenerator {
               final serialized = (entry.value as dynamic).toJson();
               if (serialized is Map) {
                 final cleaned = <String, dynamic>{};
-                for (final e in (serialized as Map).entries) {
+                for (final e in serialized.entries) {
                   if (e.value != null) cleaned[e.key.toString()] = e.value;
                 }
                 if (cleaned.isNotEmpty) result[entry.key] = cleaned;

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -61,6 +61,7 @@ class CbDelegateGenerator {
         if (hasUniqueFields) _findUnique(modelName, tableName),
         if (hasUniqueFields) _findUniqueOrThrow(modelName),
         _findFirst(modelName, tableName),
+        _findFirstOrThrow(modelName),
         _findMany(modelName, tableName),
         _findManyRaw(modelName, tableName),
         _findFirstRaw(modelName, tableName),
@@ -73,6 +74,7 @@ class CbDelegateGenerator {
         _deleteMany(modelName, tableName),
         _count(modelName, tableName),
         _groupBy(modelName, tableName),
+        _aggregate(modelName, tableName),
         _normalizeForJson(),
         if (hasUniqueFields) _whereUniqueToJson(modelName),
         _whereToJson(modelName),
@@ -156,6 +158,34 @@ class CbDelegateGenerator {
 
       final result = await _executor.executeQueryAsSingleMap(queryBuilder.build());
       return result != null ? $m.fromJson(_normalizeForJson(result)) : null;
+    '''));
+
+  Method _findFirstOrThrow(String m) => Method((b) => b
+    ..name = 'findFirstOrThrow'
+    ..docs.add('/// Find the first $m matching criteria, or throw if none')
+    ..modifier = MethodModifier.async
+    ..returns = refer('Future<$m>')
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'where'
+        ..named = true
+        ..type = refer('${m}WhereInput?')),
+      Parameter((p) => p
+        ..name = 'orderBy'
+        ..named = true
+        ..type = refer('${m}OrderByInput?')),
+      Parameter((p) => p
+        ..name = 'include'
+        ..named = true
+        ..type = refer('Map<String, dynamic>?')),
+    ])
+    ..body = Code('''
+      final result =
+          await findFirst(where: where, orderBy: orderBy, include: include);
+      if (result == null) {
+        throw Exception('$m not found');
+      }
+      return result;
     '''));
 
   Method _findMany(String m, String t) => Method((b) => b
@@ -582,6 +612,62 @@ class CbDelegateGenerator {
       if (orderBy != null) queryBuilder.orderBy(orderBy);
 
       return await _executor.executeQueryAsMaps(queryBuilder.build());
+    '''));
+
+  Method _aggregate(String m, String t) => Method((b) => b
+    ..name = 'aggregate'
+    ..docs.add('/// Aggregate over ${m}s (count/sum/avg/min/max)')
+    ..modifier = MethodModifier.async
+    ..returns = refer('Future<Map<String, dynamic>>')
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'where'
+        ..named = true
+        ..type = refer('${m}WhereInput?')),
+      Parameter((p) => p
+        ..name = 'count'
+        ..named = true
+        ..type = refer('bool?')),
+      Parameter((p) => p
+        ..name = 'sum'
+        ..named = true
+        ..type = refer('Map<String, bool>?')),
+      Parameter((p) => p
+        ..name = 'avg'
+        ..named = true
+        ..type = refer('Map<String, bool>?')),
+      Parameter((p) => p
+        ..name = 'min'
+        ..named = true
+        ..type = refer('Map<String, bool>?')),
+      Parameter((p) => p
+        ..name = 'max'
+        ..named = true
+        ..type = refer('Map<String, bool>?')),
+      Parameter((p) => p
+        ..name = 'countFiltered'
+        ..named = true
+        ..type = refer('List<Map<String, dynamic>>?')),
+    ])
+    ..body = Code('''
+      final queryBuilder = JsonQueryBuilder()
+          .model('$t')
+          .action(QueryAction.aggregate);
+
+      if (where != null) queryBuilder.where(_whereToJson(where));
+
+      final agg = <String, dynamic>{};
+      if (count == true) agg['_count'] = true;
+      if (sum != null) agg['_sum'] = sum;
+      if (avg != null) agg['_avg'] = avg;
+      if (min != null) agg['_min'] = min;
+      if (max != null) agg['_max'] = max;
+      if (countFiltered != null) agg['_countFiltered'] = countFiltered;
+      queryBuilder.aggregation(agg);
+
+      final result =
+          await _executor.executeQueryAsSingleMap(queryBuilder.build());
+      return result ?? <String, dynamic>{};
     '''));
 
   Method _normalizeForJson() => Method((b) => b

--- a/lib/src/generator/cb_filter_types_generator.dart
+++ b/lib/src/generator/cb_filter_types_generator.dart
@@ -90,6 +90,20 @@ class CbFilterTypesGenerator {
         _p('List<int>?', 'hasSome'),
         _p('bool?', 'isEmpty'),
       ]),
+      _filter('BigIntFilter', 'BigInt', [
+        _p('BigInt?', 'equals'),
+        _p('BigInt?', 'not'),
+        _pJsonKey('List<BigInt>?', 'in_', 'in'),
+        _p('List<BigInt>?', 'notIn'),
+        _p('BigInt?', 'lt'),
+        _p('BigInt?', 'lte'),
+        _p('BigInt?', 'gt'),
+        _p('BigInt?', 'gte'),
+      ]),
+      _filter('BytesFilter', 'Bytes', [
+        _p('List<int>?', 'equals'),
+        _p('List<int>?', 'not'),
+      ]),
       _filter('JsonFilter', 'Json (PostgreSQL jsonb)', [
         _p('List<String>?', 'path'),
         _p('Object?', 'equals'),
@@ -174,6 +188,10 @@ class CbFilterTypesGenerator {
     if (cleanType == 'DateTime') return '$name!.toIso8601String()';
     if (cleanType.startsWith('List<DateTime>')) {
       return '$name!.map((e) => e.toIso8601String()).toList()';
+    }
+    if (cleanType == 'BigInt') return '$name!.toString()';
+    if (cleanType.startsWith('List<BigInt>')) {
+      return '$name!.map((e) => e.toString()).toList()';
     }
 
     // Check for enum types

--- a/lib/src/generator/cb_filter_types_generator.dart
+++ b/lib/src/generator/cb_filter_types_generator.dart
@@ -90,6 +90,18 @@ class CbFilterTypesGenerator {
         _p('List<int>?', 'hasSome'),
         _p('bool?', 'isEmpty'),
       ]),
+      _filter('JsonFilter', 'Json (PostgreSQL jsonb)', [
+        _p('List<String>?', 'path'),
+        _p('Object?', 'equals'),
+        _pJsonKey('String?', 'stringContains', 'string_contains'),
+        _pJsonKey('String?', 'stringStartsWith', 'string_starts_with'),
+        _pJsonKey('String?', 'stringEndsWith', 'string_ends_with'),
+        _pJsonKey('Object?', 'arrayContains', 'array_contains'),
+        _p('Object?', 'lt'),
+        _p('Object?', 'lte'),
+        _p('Object?', 'gt'),
+        _p('Object?', 'gte'),
+      ]),
       Enum((b) => b
         ..name = 'SortOrder'
         ..docs.add('/// Sort order for ordering results')

--- a/lib/src/generator/cb_filter_types_generator.dart
+++ b/lib/src/generator/cb_filter_types_generator.dart
@@ -130,7 +130,12 @@ class CbFilterTypesGenerator {
     ];
 
     final library = Library((b) => b
-      ..comments.add('/// Generated filter types for type-safe queries')
+      ..comments.addAll([
+        '/// Generated filter types for type-safe queries',
+        // @JsonKey on freezed constructor params (e.g. `in`, `string_contains`)
+        // is a valid pattern but trips this lint; suppress it file-wide.
+        'ignore_for_file: invalid_annotation_target',
+      ])
       ..directives.addAll(directives)
       ..body.addAll(body));
 

--- a/lib/src/generator/cb_filter_types_generator.dart
+++ b/lib/src/generator/cb_filter_types_generator.dart
@@ -25,19 +25,45 @@ class CbFilterTypesGenerator {
     ];
 
     final body = <Spec>[
-      _filter('StringFilter', 'String', [
-        _p('String?', 'equals'),
-        _p('String?', 'not'),
-        _pJsonKey('List<String>?', 'in_', 'in'),
-        _p('List<String>?', 'notIn'),
-        _p('String?', 'contains'),
-        _p('String?', 'startsWith'),
-        _p('String?', 'endsWith'),
-        _p('String?', 'lt'),
-        _p('String?', 'lte'),
-        _p('String?', 'gt'),
-        _p('String?', 'gte'),
-      ]),
+      _filter(
+        'StringFilter',
+        'String',
+        [
+          _p('String?', 'equals'),
+          _p('String?', 'not'),
+          _pJsonKey('List<String>?', 'in_', 'in'),
+          _p('List<String>?', 'notIn'),
+          _p('String?', 'contains'),
+          _p('String?', 'startsWith'),
+          _p('String?', 'endsWith'),
+          _p('String?', 'lt'),
+          _p('String?', 'lte'),
+          _p('String?', 'gt'),
+          _p('String?', 'gte'),
+          // 'insensitive' → case-insensitive contains/startsWith/endsWith.
+          _p('String?', 'mode'),
+        ],
+        // When mode is set, wrap the string-search operators as
+        // {value, mode} so the compiler emits ILIKE (matches Prisma).
+        toJsonBodyOverride: '''
+          String? m = mode;
+          Object? wrap(String? v) =>
+              (v != null && m != null) ? <String, dynamic>{'value': v, 'mode': m} : v;
+          return <String, dynamic>{
+            if (equals != null) 'equals': equals,
+            if (not != null) 'not': not,
+            if (in_ != null) 'in': in_,
+            if (notIn != null) 'notIn': notIn,
+            if (contains != null) 'contains': wrap(contains),
+            if (startsWith != null) 'startsWith': wrap(startsWith),
+            if (endsWith != null) 'endsWith': wrap(endsWith),
+            if (lt != null) 'lt': lt,
+            if (lte != null) 'lte': lte,
+            if (gt != null) 'gt': gt,
+            if (gte != null) 'gte': gte,
+          };
+        ''',
+      ),
       _filter('IntFilter', 'Int', [
         _p('int?', 'equals'),
         _p('int?', 'not'),
@@ -142,8 +168,9 @@ class CbFilterTypesGenerator {
     return _formatter.format('${library.accept(_emitter)}');
   }
 
-  Class _filter(String name, String doc, List<Parameter> params) {
-    final toJsonBody = _filterToJsonBody(params);
+  Class _filter(String name, String doc, List<Parameter> params,
+      {String? toJsonBodyOverride}) {
+    final toJsonBody = toJsonBodyOverride ?? _filterToJsonBody(params);
     return Class((b) => b
       ..name = name
       ..docs.add('/// Filter for $doc fields')

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -48,6 +48,7 @@ class CbModelGenerator {
         _buildRelationFilter(model),
         _buildOrderByInput(model),
         _buildInclude(model),
+        ..._buildRelationWriteInputs(model),
         ..._buildEnumConverters(model),
       ]));
 
@@ -279,6 +280,10 @@ class CbModelGenerator {
         entries.add("'$name': $expr");
       }
     }
+    // Nested relation writes (create/connect/disconnect) are always optional.
+    for (final f in model.fields.where((f) => f.isRelation)) {
+      entries.add("if (${f.name} != null) '${f.name}': ${f.name}!.toJson()");
+    }
     return 'return <String, dynamic>{${entries.join(', ')},};';
   }
 
@@ -427,6 +432,7 @@ class CbModelGenerator {
       }
       params.add(_createInputParam(f));
     }
+    _addRelationWriteParams(model, params);
 
     return _freezedClass('Create${model.name}Input', params,
         doc: '/// Input for creating a new ${model.name}',
@@ -484,6 +490,7 @@ class CbModelGenerator {
         ..named = true
         ..type = refer(f.isList ? 'List<$dartType>?' : '$dartType?')));
     }
+    _addRelationWriteParams(model, params);
 
     return _freezedClass('Update${model.name}Input', params,
         doc: '/// Input for updating an existing ${model.name}',
@@ -658,6 +665,85 @@ class CbModelGenerator {
             "if (is_ != null) 'is': is_!.toJson(), "
             "if (isNot != null) 'isNot': isNot!.toJson(),"
             "};");
+  }
+
+  // === Nested relation write inputs (create/connect/disconnect) ===
+
+  String _relationWriteTypeName(PrismaModel model, PrismaField f) =>
+      '${model.name}${f.name[0].toUpperCase()}${f.name.substring(1)}WriteInput';
+
+  /// Append one optional nested-write param per relation to a Create/Update
+  /// input's param list, typed to the relation's `${...}WriteInput` class.
+  void _addRelationWriteParams(PrismaModel model, List<Parameter> params) {
+    for (final f in model.fields.where((f) => f.isRelation)) {
+      params.add(Parameter((p) => p
+        ..name = f.name
+        ..named = true
+        ..type = refer('${_relationWriteTypeName(model, f)}?')));
+    }
+  }
+
+  /// Whether the related model exposes a WhereUniqueInput (field-level unique
+  /// or a composite key) — required for connect/disconnect.
+  bool _relatedHasWhereUnique(String relatedModel) {
+    final m = schema.models.where((m) => m.name == relatedModel).firstOrNull;
+    if (m == null) return false;
+    return m.fields.any((f) => (f.isId || f.isUnique) && !f.isRelation) ||
+        m.compositeUniques.isNotEmpty;
+  }
+
+  /// One nested-write input per relation: `connect`/`disconnect` (when the
+  /// related model has a unique key) and `create`. toJson yields the shape the
+  /// relation-mutation compiler consumes.
+  List<Spec> _buildRelationWriteInputs(PrismaModel model) {
+    final specs = <Spec>[];
+    for (final f in model.fields.where((f) => f.isRelation)) {
+      final related = f.type;
+      final canConnect = _relatedHasWhereUnique(related);
+      final params = <Parameter>[];
+      final entries = <String>[];
+
+      if (f.isList) {
+        if (canConnect) {
+          params.add(Parameter((p) => p
+            ..name = 'connect'
+            ..named = true
+            ..type = refer('List<${related}WhereUniqueInput>?')));
+          params.add(Parameter((p) => p
+            ..name = 'disconnect'
+            ..named = true
+            ..type = refer('List<${related}WhereUniqueInput>?')));
+          entries.add(
+              "if (connect != null) 'connect': connect!.map((e) => e.toJson()).toList()");
+          entries.add(
+              "if (disconnect != null) 'disconnect': disconnect!.map((e) => e.toJson()).toList()");
+        }
+        params.add(Parameter((p) => p
+          ..name = 'create'
+          ..named = true
+          ..type = refer('List<Create${related}Input>?')));
+        entries.add(
+            "if (create != null) 'create': create!.map((e) => e.toJson()).toList()");
+      } else {
+        if (canConnect) {
+          params.add(Parameter((p) => p
+            ..name = 'connect'
+            ..named = true
+            ..type = refer('${related}WhereUniqueInput?')));
+          entries.add("if (connect != null) 'connect': connect!.toJson()");
+        }
+        params.add(Parameter((p) => p
+          ..name = 'create'
+          ..named = true
+          ..type = refer('Create${related}Input?')));
+        entries.add("if (create != null) 'create': create!.toJson()");
+      }
+
+      specs.add(_freezedClass(_relationWriteTypeName(model, f), params,
+          doc: '/// Nested write for ${model.name}.${f.name}',
+          toJsonBody: 'return <String, dynamic>{${entries.join(', ')},};'));
+    }
+    return specs;
   }
 
   // === Include (typed relation selection) ===

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -977,6 +977,7 @@ class CbModelGenerator {
       'Float' || 'Decimal' => 'FloatFilter',
       'Boolean' => 'BooleanFilter',
       'DateTime' => 'DateTimeFilter',
+      'Json' => 'JsonFilter',
       _ => _isEnumType(f.type) ? '${f.type}Filter' : null,
     };
   }

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -978,6 +978,8 @@ class CbModelGenerator {
       'Boolean' => 'BooleanFilter',
       'DateTime' => 'DateTimeFilter',
       'Json' => 'JsonFilter',
+      'BigInt' => 'BigIntFilter',
+      'Bytes' => 'BytesFilter',
       _ => _isEnumType(f.type) ? '${f.type}Filter' : null,
     };
   }

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -23,10 +23,13 @@ class CbModelGenerator {
   String generateModel(PrismaModel model) {
     final sn = toSnakeCase(model.name);
 
-    // Collect non-primitive type imports
+    // Collect non-primitive type imports (excluding the model's own type,
+    // which would be a redundant self-import for self-relations).
     final typeImports = <String>{};
     for (final f in model.fields) {
-      if (!_isPrimitiveType(f.type)) typeImports.add(f.type);
+      if (!_isPrimitiveType(f.type) && f.type != model.name) {
+        typeImports.add(f.type);
+      }
     }
 
     final directives = <Directive>[
@@ -37,6 +40,11 @@ class CbModelGenerator {
     ];
 
     final library = Library((b) => b
+      ..comments.add(
+        // @JsonKey on freezed constructor params (@map columns, relation
+        // fields) is a valid pattern that trips this lint; suppress file-wide.
+        'ignore_for_file: invalid_annotation_target',
+      )
       ..directives.addAll(directives)
       ..body.addAll([
         _buildMainClass(model),

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -269,6 +269,11 @@ class CbModelGenerator {
   }
 
   /// Generate toJson body for WhereUniqueInput.
+  ///
+  /// Compound keys are FLATTENED into their individual field equalities, so
+  /// the SQL compiler needs no compound-key awareness: findUnique/update/
+  /// delete get `col_a = ? AND col_b = ?` and upsert gets the right
+  /// `ON CONFLICT (col_a, col_b)`.
   String _generateWhereUniqueToJsonBody(PrismaModel model) {
     final uniqueFields =
         model.fields.where((f) => (f.isId || f.isUnique) && !f.isRelation);
@@ -276,8 +281,17 @@ class CbModelGenerator {
     for (final f in uniqueFields) {
       entries.add("if (${f.name} != null) '${f.name}': ${f.name}");
     }
+    for (final key in model.compositeUniques) {
+      final fieldName = key.join('_');
+      entries.add('if ($fieldName != null) ...$fieldName!.toJson()');
+    }
     return 'return <String, dynamic>{${entries.join(', ')},};';
   }
+
+  /// The generated compound-unique input type name, e.g.
+  /// `OrgInvoiceCounterOrganizationIdFiscalYearCompoundUnique`.
+  String _compoundTypeName(PrismaModel model, List<String> key) =>
+      '${model.name}${key.map((k) => k[0].toUpperCase() + k.substring(1)).join()}CompoundUnique';
 
   /// Generate toJson body for WhereInput.
   String _generateWhereInputToJsonBody(PrismaModel model) {
@@ -457,19 +471,51 @@ class CbModelGenerator {
   // === WhereUniqueInput ===
 
   List<Spec> _buildWhereUniqueInput(PrismaModel model) {
-    final uniqueFields =
-        model.fields.where((f) => (f.isId || f.isUnique) && !f.isRelation);
-    if (uniqueFields.isEmpty) return [];
+    final uniqueFields = model.fields
+        .where((f) => (f.isId || f.isUnique) && !f.isRelation)
+        .toList();
+    final composites = model.compositeUniques;
+    if (uniqueFields.isEmpty && composites.isEmpty) return [];
 
-    final params = uniqueFields.map((f) => Parameter((p) => p
-      ..name = f.name
-      ..named = true
-      ..type = refer(f.isList ? 'List<${f.type}>?' : '${f.type}?')));
+    final specs = <Spec>[];
+    final params = <Parameter>[];
 
-    return [
-      _freezedClass('${model.name}WhereUniqueInput', params.toList(),
-          toJsonBody: _generateWhereUniqueToJsonBody(model))
-    ];
+    for (final f in uniqueFields) {
+      params.add(Parameter((p) => p
+        ..name = f.name
+        ..named = true
+        ..type = refer(f.isList ? 'List<${f.type}>?' : '${f.type}?')));
+    }
+
+    // One compound-unique input class per @@id/@@unique composite key.
+    for (final key in composites) {
+      final typeName = _compoundTypeName(model, key);
+      params.add(Parameter((p) => p
+        ..name = key.join('_')
+        ..named = true
+        ..type = refer('$typeName?')));
+
+      final compoundParams = <Parameter>[];
+      final entries = <String>[];
+      for (final fieldName in key) {
+        final f = model.fields.firstWhere((mf) => mf.name == fieldName,
+            orElse: () => throw StateError(
+                'Composite key field "$fieldName" not found on ${model.name}'));
+        compoundParams.add(Parameter((p) => p
+          ..name = fieldName
+          ..named = true
+          ..required = true
+          ..type = refer(_toDartType(f.type))));
+        entries.add("'$fieldName': $fieldName");
+      }
+      specs.add(_freezedClass(typeName, compoundParams,
+          doc: '/// Compound unique key ($key) for ${model.name}',
+          toJsonBody: 'return <String, dynamic>{${entries.join(', ')},};'));
+    }
+
+    specs.add(_freezedClass('${model.name}WhereUniqueInput', params,
+        toJsonBody: _generateWhereUniqueToJsonBody(model)));
+    return specs;
   }
 
   // === WhereInput ===

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -47,6 +47,7 @@ class CbModelGenerator {
         _buildListRelationFilter(model),
         _buildRelationFilter(model),
         _buildOrderByInput(model),
+        _buildInclude(model),
         ..._buildEnumConverters(model),
       ]));
 
@@ -91,15 +92,36 @@ class CbModelGenerator {
   // === Manual fromJson ===
 
   /// Generate manual fromJson body for the main model class.
+  ///
+  /// Relation fields ARE hydrated when present in the JSON (produced by an
+  /// `include`): the RelationDeserializer nests related rows under the
+  /// relation key, and here we deserialize them into the typed relation
+  /// model. Absent keys (no include) leave the relation null / empty.
   String _generateFromJsonBody(PrismaModel model) {
     final args = <String>[];
     for (final f in model.fields) {
-      if (f.isRelation) continue; // Skip relations
+      if (f.isRelation) {
+        args.add('${f.name}: ${_relationFromJsonExpr(f)}');
+        continue;
+      }
       final dartType = _toDartType(f.type);
       final key = f.dbName ?? f.name;
       args.add('${f.name}: ${_fromJsonExpr(f, key, dartType)}');
     }
     return 'return ${model.name}(${args.join(', ')},);';
+  }
+
+  /// fromJson expression for a relation field (nested typed model / list).
+  String _relationFromJsonExpr(PrismaField f) {
+    final key = f.name; // relation keys are not @map-ed
+    if (f.isList) {
+      return "(json['$key'] as List?)"
+          "?.map((e) => ${f.type}.fromJson(e as Map<String, dynamic>))"
+          ".toList() ?? const []";
+    }
+    return "json['$key'] != null "
+        "? ${f.type}.fromJson(json['$key'] as Map<String, dynamic>) "
+        ": null";
   }
 
   /// Generate a fromJson expression for a single field.
@@ -636,6 +658,34 @@ class CbModelGenerator {
             "if (is_ != null) 'is': is_!.toJson(), "
             "if (isNot != null) 'isNot': isNot!.toJson(),"
             "};");
+  }
+
+  // === Include (typed relation selection) ===
+
+  /// Typed include class: one `${RelatedModel}Include?` field per relation.
+  /// A non-null nested include includes that relation (empty = include with no
+  /// deeper relations); toJson yields the compiler's include-map shape.
+  Class _buildInclude(PrismaModel model) {
+    final relations = model.fields.where((f) => f.isRelation).toList();
+    final params = <Parameter>[];
+    // Statement-style toJson (no runtime helper): an empty nested include
+    // serializes to `true` (include, no deeper relations); a non-empty one
+    // nests via {'include': ...}, matching the relation compiler's shape.
+    final stmts = <String>['final map = <String, dynamic>{};'];
+    for (final f in relations) {
+      params.add(Parameter((p) => p
+        ..name = f.name
+        ..named = true
+        ..type = refer('${f.type}Include?')));
+      stmts.add("if (${f.name} != null) {"
+          " final n = ${f.name}!.toJson();"
+          " map['${f.name}'] = n.isEmpty ? true : <String, dynamic>{'include': n};"
+          " }");
+    }
+    stmts.add('return map;');
+    return _freezedClass('${model.name}Include', params,
+        doc: '/// Typed include for ${model.name} relations',
+        toJsonBody: stmts.join('\n'));
   }
 
   // === OrderByInput ===

--- a/lib/src/generator/prisma_parser.dart
+++ b/lib/src/generator/prisma_parser.dart
@@ -107,11 +107,17 @@ class PrismaModel {
   final List<PrismaField> fields;
   final List<PrismaRelation> relations;
 
+  /// Composite unique keys from block attributes: `@@id([a, b])` (also treated
+  /// as a unique) and each `@@unique([a, b])`. Single-field lists are omitted
+  /// (those are covered by field-level `@id`/`@unique`).
+  final List<List<String>> compositeUniques;
+
   const PrismaModel({
     required this.name,
     this.dbName,
     required this.fields,
     required this.relations,
+    this.compositeUniques = const [],
   });
 
   /// Get the database table name (original name if renamed, otherwise model name)
@@ -470,15 +476,31 @@ class PrismaParser {
       // renames for the database table name. Match line-by-line with
       // comments stripped so a commented-out `// @@map("x")` is ignored.
       String? explicitTableName;
+      // Composite unique keys from @@id([...]) and @@unique([...]).
+      final compositeUniques = <List<String>>[];
       for (final line in modelBody.split('\n')) {
         var active = line;
         final commentIndex = active.indexOf('//');
         if (commentIndex >= 0) active = active.substring(0, commentIndex);
-        final match =
-            RegExp(r'^@@map\(\s*"([^"]+)"\s*\)').firstMatch(active.trim());
-        if (match != null) {
-          explicitTableName = match.group(1);
-          break;
+        active = active.trim();
+        final mapMatch =
+            RegExp(r'^@@map\(\s*"([^"]+)"\s*\)').firstMatch(active);
+        if (mapMatch != null) {
+          explicitTableName = mapMatch.group(1);
+          continue;
+        }
+        final keyMatch =
+            RegExp(r'^@@(id|unique)\(\s*\[([^\]]*)\]').firstMatch(active);
+        if (keyMatch != null) {
+          final parts = keyMatch
+              .group(2)!
+              .split(',')
+              .map((f) => f.trim())
+              .where((f) => f.isNotEmpty)
+              .toList();
+          // Only composite (>1) keys need a compound input; single-field
+          // @@unique is already addressable via the field-level unique.
+          if (parts.length > 1) compositeUniques.add(parts);
         }
       }
       final modelDbName = explicitTableName ?? modelResult.dbName;
@@ -656,6 +678,7 @@ class PrismaParser {
         dbName: modelDbName,
         fields: fields,
         relations: relations,
+        compositeUniques: compositeUniques,
       ));
     }
 

--- a/lib/src/runtime/adapters/postgres_adapter.dart
+++ b/lib/src/runtime/adapters/postgres_adapter.dart
@@ -29,28 +29,60 @@ import 'package:prisma_flutter_connector/src/runtime/adapters/types.dart';
 /// final prisma = PrismaClient(adapter: adapter);
 /// ```
 class PostgresAdapter implements SqlDriverAdapter {
-  pg.Connection _connection;
+  /// Single dedicated connection (single-connection mode). Null when pooled.
+  pg.Connection? _connection;
+
+  /// Connection pool (pooled mode). Null in single-connection mode.
+  final pg.Pool? _pool;
+
   final ConnectionInfo? _connectionInfo;
   final Future<pg.Connection> Function()? _connectionFactory;
 
   PostgresAdapter(
-    this._connection, {
+    pg.Connection connection, {
     ConnectionInfo? connectionInfo,
     Future<pg.Connection> Function()? connectionFactory,
-  })  : _connectionInfo = connectionInfo,
+  })  : _connection = connection,
+        _pool = null,
+        _connectionInfo = connectionInfo,
         _connectionFactory = connectionFactory;
 
+  /// Pooled adapter (#70). Non-transactional queries run on connections
+  /// borrowed from [pool]; each transaction pins a dedicated pool connection
+  /// for its lifetime. Construct the pool with `pg.Pool.withEndpoints(...)`
+  /// or `pg.Pool.withUrl(...)`.
+  PostgresAdapter.pooled(
+    pg.Pool pool, {
+    ConnectionInfo? connectionInfo,
+  })  : _connection = null,
+        _pool = pool,
+        _connectionInfo = connectionInfo,
+        _connectionFactory = null;
+
+  /// Whether this adapter is pool-backed.
+  bool get isPooled => _pool != null;
+
+  /// The Session used for non-transactional statements: the pinned connection
+  /// in single-connection mode, or the pool (which dispatches per-statement) in
+  /// pooled mode.
+  pg.Session get _session {
+    final pg.Session? conn = _connection;
+    return conn ?? _pool!;
+  }
+
   /// Check if connection is alive, reconnect if factory provided.
+  /// No-op in pooled mode (the pool manages connection health).
   Future<void> _ensureConnected() async {
-    if (_connectionFactory == null) return;
+    final conn = _connection;
+    if (conn == null || _connectionFactory == null) return;
     try {
-      await _connection.execute('SELECT 1').timeout(
+      await conn.execute('SELECT 1').timeout(
             const Duration(seconds: 5),
           );
     } catch (_) {
       // Connection dead — attempt reconnect
       try {
-        await _connection.close();
+        await conn.close();
       } catch (_) {
         // Already closed, ignore
       }
@@ -72,7 +104,7 @@ class PostgresAdapter implements SqlDriverAdapter {
       final convertedArgs = _convertArgs(query.args, query.argTypes);
 
       // Execute query - don't use pg.Sql.indexed since we already have placeholders
-      final result = await _connection.execute(
+      final result = await _session.execute(
         query.sql,
         parameters: convertedArgs.isEmpty ? null : convertedArgs,
       );
@@ -94,7 +126,7 @@ class PostgresAdapter implements SqlDriverAdapter {
       await _ensureConnected();
       final convertedArgs = _convertArgs(query.args, query.argTypes);
 
-      final result = await _connection.execute(
+      final result = await _session.execute(
         query.sql,
         parameters: convertedArgs.isEmpty ? null : convertedArgs,
       );
@@ -116,7 +148,7 @@ class PostgresAdapter implements SqlDriverAdapter {
       final statements = script.split(';').where((s) => s.trim().isNotEmpty);
 
       for (final statement in statements) {
-        await _connection.execute(statement.trim());
+        await _session.execute(statement.trim());
       }
     } catch (e) {
       throw AdapterError(
@@ -129,7 +161,12 @@ class PostgresAdapter implements SqlDriverAdapter {
 
   @override
   Future<Transaction> startTransaction([IsolationLevel? isolationLevel]) async {
-    return PostgresTransaction._start(_connection, isolationLevel);
+    final pool = _pool;
+    if (pool != null) {
+      // Pin a dedicated pool connection for the transaction's lifetime.
+      return PostgresTransaction._startPooled(pool, isolationLevel);
+    }
+    return PostgresTransaction._start(_connection!, isolationLevel);
   }
 
   @override
@@ -143,7 +180,12 @@ class PostgresAdapter implements SqlDriverAdapter {
 
   @override
   Future<void> dispose() async {
-    await _connection.close();
+    final pool = _pool;
+    if (pool != null) {
+      await pool.close();
+    } else {
+      await _connection?.close();
+    }
   }
 
   /// Convert Dart values to PostgreSQL-compatible format.
@@ -380,11 +422,16 @@ class PostgresAdapter implements SqlDriverAdapter {
 /// PostgreSQL transaction implementation.
 class PostgresTransaction implements Transaction {
   final pg.Connection _connection;
+
+  /// When pool-backed, completing this returns the pinned connection to the
+  /// pool. Null for single-connection transactions.
+  final Completer<void>? _release;
+
   bool _isActive = true;
   bool _isCommitted = false;
   bool _isRolledBack = false;
 
-  PostgresTransaction._(this._connection);
+  PostgresTransaction._(this._connection, [this._release]);
 
   static Future<PostgresTransaction> _start(
     pg.Connection connection,
@@ -401,6 +448,41 @@ class PostgresTransaction implements Transaction {
     }
 
     return PostgresTransaction._(connection);
+  }
+
+  /// Borrow a dedicated connection from [pool] and pin it for the transaction's
+  /// lifetime. `withConnection` keeps the connection out of the pool until the
+  /// [_release] completer fires (on commit/rollback), so every statement in the
+  /// transaction runs on the same physical connection.
+  static Future<PostgresTransaction> _startPooled(
+    pg.Pool pool,
+    IsolationLevel? isolationLevel,
+  ) async {
+    final ready = Completer<pg.Connection>();
+    final release = Completer<void>();
+
+    unawaited(pool.withConnection((conn) async {
+      ready.complete(conn);
+      await release.future;
+    }).catchError((Object e, StackTrace st) {
+      if (!ready.isCompleted) ready.completeError(e, st);
+    }));
+
+    final connection = await ready.future;
+    try {
+      await connection.execute('BEGIN');
+      if (isolationLevel != null) {
+        await connection.execute(
+          'SET TRANSACTION ISOLATION LEVEL ${isolationLevel.sql}',
+        );
+      }
+    } catch (e) {
+      // Hand the connection back to the pool if setup failed.
+      if (!release.isCompleted) release.complete();
+      rethrow;
+    }
+
+    return PostgresTransaction._(connection, release);
   }
 
   @override
@@ -444,6 +526,9 @@ class PostgresTransaction implements Transaction {
         'Failed to commit transaction: ${e.toString()}',
         originalError: e,
       );
+    } finally {
+      final release = _release;
+      if (release != null && !release.isCompleted) release.complete();
     }
   }
 
@@ -460,6 +545,9 @@ class PostgresTransaction implements Transaction {
         'Failed to rollback transaction: ${e.toString()}',
         originalError: e,
       );
+    } finally {
+      final release = _release;
+      if (release != null && !release.isCompleted) release.complete();
     }
   }
 

--- a/lib/src/runtime/logging/sentry_query_logger.dart
+++ b/lib/src/runtime/logging/sentry_query_logger.dart
@@ -1,0 +1,93 @@
+/// Sentry integration for the query pipeline.
+///
+/// Bundles Sentry error reporting into the connector without hijacking the
+/// host application's Sentry setup: it only *captures* exceptions, and only
+/// when Sentry has already been initialized (`Sentry.isEnabled`). Plug it in
+/// via the executor's `logger`, e.g.:
+///
+/// ```dart
+/// QueryExecutor(
+///   adapter: adapter,
+///   logger: const CompositeQueryLogger([
+///     ConsoleQueryLogger(),
+///     SentryQueryLogger(),
+///   ]),
+/// );
+/// ```
+///
+/// If you want the connector to own Sentry initialization (standalone use,
+/// e.g. tooling/examples), call [PrismaSentry.init] once at startup.
+library;
+
+import 'package:sentry/sentry.dart';
+
+import 'package:prisma_flutter_connector/src/runtime/logging/query_logger.dart';
+
+/// A [QueryLogger] that forwards failed queries to Sentry.
+///
+/// Successful queries are ignored; failures are reported via
+/// [Sentry.captureException] with the SQL/operation/model attached as context.
+/// No-ops when Sentry is not enabled, so it is always safe to include.
+class SentryQueryLogger implements QueryLogger {
+  /// Whether to attach bound parameters to the Sentry event. Off by default
+  /// because parameters may contain PII / secrets.
+  final bool includeParameters;
+
+  const SentryQueryLogger({this.includeParameters = false});
+
+  @override
+  void onQueryStart(QueryStartEvent event) {}
+
+  @override
+  void onQueryEnd(QueryEndEvent event) {}
+
+  @override
+  void onQueryError(QueryErrorEvent event) {
+    if (!Sentry.isEnabled) return;
+    Sentry.captureException(
+      event.error,
+      stackTrace: event.stackTrace,
+      withScope: (scope) {
+        scope.setContexts('prisma_query', {
+          if (event.operation != null) 'operation': event.operation,
+          if (event.model != null) 'model': event.model,
+          'sql': event.sql,
+          'durationMs': event.duration.inMilliseconds,
+          if (includeParameters) 'parameters': event.parameters.toString(),
+        });
+      },
+    );
+  }
+}
+
+/// Convenience Sentry initialization for standalone connector usage.
+///
+/// Most apps (including the familiarise mobile backend) already call
+/// `Sentry.init`/`SentryFlutter.init` themselves — in that case you do NOT
+/// need this; just add [SentryQueryLogger] to the executor. Use this only when
+/// the connector is the top-level owner of Sentry.
+class PrismaSentry {
+  PrismaSentry._();
+
+  /// Default DSN for the prisma_flutter_connector Sentry project. Override via
+  /// the `SENTRY_DSN` dart-define or the [dsn] argument.
+  static const defaultDsn = String.fromEnvironment(
+    'SENTRY_DSN',
+    defaultValue:
+        'https://f7e4fda3e20074d189fd615518b38918@o4509348815372289.ingest.us.sentry.io/4511666594185216',
+  );
+
+  /// Initialize Sentry if it isn't already. Safe to call once at startup.
+  static Future<void> init({
+    String? dsn,
+    bool sendDefaultPii = true,
+    void Function(SentryOptions)? configure,
+  }) async {
+    if (Sentry.isEnabled) return;
+    await Sentry.init((options) {
+      options.dsn = dsn ?? defaultDsn;
+      options.sendDefaultPii = sendDefaultPii;
+      configure?.call(options);
+    });
+  }
+}

--- a/lib/src/runtime/query/json_protocol.dart
+++ b/lib/src/runtime/query/json_protocol.dart
@@ -133,6 +133,7 @@ class JsonQueryBuilder {
   Map<String, ComputedField>? _computed;
   int? _take;
   int? _skip;
+  Map<String, dynamic>? _cursor;
   bool _distinct = false;
   List<String>? _distinctFields;
   final bool _selectScalars = true;
@@ -252,6 +253,15 @@ class JsonQueryBuilder {
     return this;
   }
 
+  /// Set the cursor for keyset pagination. The map is a unique-key value
+  /// (e.g. `{'id': 'abc'}`); the compiler derives a keyset predicate from it
+  /// and the current `orderBy`. Inclusive of the cursor row — pair with
+  /// `skip(1)` to exclude it, matching Prisma.
+  JsonQueryBuilder cursor(Map<String, dynamic> cursor) {
+    _cursor = cursor;
+    return this;
+  }
+
   /// Set aggregation functions for aggregate queries.
   ///
   /// Example:
@@ -328,6 +338,7 @@ class JsonQueryBuilder {
     if (_orderBy != null) arguments['orderBy'] = _orderBy;
     if (_take != null) arguments['take'] = _take;
     if (_skip != null) arguments['skip'] = _skip;
+    if (_cursor != null) arguments['cursor'] = _cursor;
     if (_aggregate != null) arguments['_aggregate'] = _aggregate;
     if (_groupBy != null) arguments['by'] = _groupBy;
     if (_selectFields != null) arguments['selectFields'] = _selectFields;

--- a/lib/src/runtime/query/json_protocol.dart
+++ b/lib/src/runtime/query/json_protocol.dart
@@ -104,6 +104,7 @@ enum QueryAction {
   findMany('findMany'),
   create('create'),
   createMany('createMany'),
+  createManyAndReturn('createManyAndReturn'),
   update('update'),
   updateMany('updateMany'),
   upsert('upsert'),
@@ -134,6 +135,7 @@ class JsonQueryBuilder {
   int? _take;
   int? _skip;
   Map<String, dynamic>? _cursor;
+  bool _skipDuplicates = false;
   bool _distinct = false;
   List<String>? _distinctFields;
   final bool _selectScalars = true;
@@ -262,6 +264,13 @@ class JsonQueryBuilder {
     return this;
   }
 
+  /// For createMany/createManyAndReturn: skip rows that violate a unique
+  /// constraint instead of erroring (`ON CONFLICT DO NOTHING`).
+  JsonQueryBuilder skipDuplicates([bool value = true]) {
+    _skipDuplicates = value;
+    return this;
+  }
+
   /// Set aggregation functions for aggregate queries.
   ///
   /// Example:
@@ -339,6 +348,7 @@ class JsonQueryBuilder {
     if (_take != null) arguments['take'] = _take;
     if (_skip != null) arguments['skip'] = _skip;
     if (_cursor != null) arguments['cursor'] = _cursor;
+    if (_skipDuplicates) arguments['skipDuplicates'] = true;
     if (_aggregate != null) arguments['_aggregate'] = _aggregate;
     if (_groupBy != null) arguments['by'] = _groupBy;
     if (_selectFields != null) arguments['selectFields'] = _selectFields;

--- a/lib/src/runtime/query/query_executor.dart
+++ b/lib/src/runtime/query/query_executor.dart
@@ -144,6 +144,14 @@ abstract class BaseExecutor {
   /// Close the underlying connection. No-op when inside a transaction (a
   /// transaction does not own the adapter's connection lifecycle).
   Future<void> dispose();
+
+  /// Run a create/update whose data contains nested relation operations
+  /// (connect/disconnect/create), atomically, and return the RETURNING row.
+  /// On a root executor this opens a transaction; inside a transaction it
+  /// reuses the ambient one.
+  Future<Map<String, dynamic>?> executeMutationWithRelationsReturning(
+    JsonQuery query,
+  );
 }
 
 /// Executes Prisma queries against a database adapter.
@@ -421,10 +429,16 @@ class QueryExecutor with ResultSetConverter implements BaseExecutor {
 
     // Execute main mutation
     final result = await adapter.queryRaw(compiled.mainQuery);
+    final mainRow =
+        result.rows.isNotEmpty ? resultSetToMaps(result).first : null;
 
-    // Execute relation mutations if any
-    if (compiled.hasRelationMutations) {
-      for (final relationQuery in compiled.relationMutations) {
+    // Rebuild relation mutations from the RETURNING row so DB-generated parent
+    // ids (e.g. @default(uuid())) are used, not the compile-time (null) id.
+    final relationMutations =
+        compiler.buildRelationMutationsFromResult(query, mainRow);
+
+    if (relationMutations.isNotEmpty) {
+      for (final relationQuery in relationMutations) {
         try {
           await adapter.executeRaw(relationQuery);
         } catch (e, s) {
@@ -446,10 +460,7 @@ class QueryExecutor with ResultSetConverter implements BaseExecutor {
     }
 
     // Return the created/updated record
-    if (result.rows.isNotEmpty) {
-      return resultSetToMaps(result).first;
-    }
-    return null;
+    return mainRow;
   }
 
   /// Execute a mutation with relation operations inside a transaction.
@@ -483,17 +494,18 @@ class QueryExecutor with ResultSetConverter implements BaseExecutor {
 
       // Execute main mutation
       final result = await txExecutor.transaction.queryRaw(compiled.mainQuery);
+      final mainRow =
+          result.rows.isNotEmpty ? resultSetToMaps(result).first : null;
 
-      // Execute relation mutations
-      for (final relationQuery in compiled.relationMutations) {
+      // Rebuild relation mutations from the RETURNING row so DB-generated
+      // parent ids are used (fixes nested writes on @default(uuid()) create).
+      final relationMutations =
+          compiler.buildRelationMutationsFromResult(query, mainRow);
+      for (final relationQuery in relationMutations) {
         await txExecutor.transaction.executeRaw(relationQuery);
       }
 
-      // Return the created/updated record
-      if (result.rows.isNotEmpty) {
-        return resultSetToMaps(result).first;
-      }
-      return null;
+      return mainRow;
     }, isolationLevel: isolationLevel);
   }
 
@@ -643,6 +655,12 @@ class QueryExecutor with ResultSetConverter implements BaseExecutor {
   }) =>
       executeInTransaction<T>(callback, isolationLevel: isolationLevel);
 
+  @override
+  Future<Map<String, dynamic>?> executeMutationWithRelationsReturning(
+    JsonQuery query,
+  ) =>
+      executeMutationWithRelationsAtomic(query);
+
   /// Close the adapter connection.
   @override
   Future<void> dispose() async {
@@ -791,6 +809,23 @@ class TransactionExecutor with ResultSetConverter implements BaseExecutor {
     // $transaction flattens). PostgreSQL has no true nested transactions and
     // the isolation level cannot change mid-transaction, so it is ignored.
     return callback(this);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> executeMutationWithRelationsReturning(
+    JsonQuery query,
+  ) async {
+    // Runs within the ambient transaction (no new BEGIN).
+    final compiled = compiler.compileWithRelations(query);
+    final result = await transaction.queryRaw(compiled.mainQuery);
+    final mainRow =
+        result.rows.isNotEmpty ? resultSetToMaps(result).first : null;
+    final relationMutations =
+        compiler.buildRelationMutationsFromResult(query, mainRow);
+    for (final relationQuery in relationMutations) {
+      await transaction.executeRaw(relationQuery);
+    }
+    return mainRow;
   }
 
   @override

--- a/lib/src/runtime/query/query_executor.dart
+++ b/lib/src/runtime/query/query_executor.dart
@@ -42,8 +42,13 @@ mixin ResultSetConverter {
         final columnName = result.columnNames[i];
         final value = i < row.length ? row[i] : null;
 
-        // Convert snake_case column names to camelCase (unless preserving aliases)
-        final key = preserveAliases ? columnName : snakeToCamelCase(columnName);
+        // Keep raw DB column names as keys. Generated models deserialize by
+        // column name (`@JsonKey(name: '<@map column>')` / manual fromJson
+        // reading the DB column), so camelCasing here would desync `@map`-ed
+        // columns (e.g. `author_id` -> `authorId`) from what fromJson reads.
+        // (`preserveAliases` is retained for API compatibility; both branches
+        // now keep the raw column/alias.)
+        final key = columnName;
 
         map[key] = deserializeValue(value, result.columnTypes[i]);
       }

--- a/lib/src/runtime/query/query_executor.dart
+++ b/lib/src/runtime/query/query_executor.dart
@@ -128,6 +128,22 @@ abstract class BaseExecutor {
 
   /// Execute a count query.
   Future<int> executeCount(JsonQuery query);
+
+  /// Run [callback] inside a transaction.
+  ///
+  /// On a root executor this opens a new transaction. On an executor that is
+  /// already inside a transaction, it reuses the ambient transaction so a
+  /// nested `$transaction` flattens instead of failing (PostgreSQL has no true
+  /// nested transactions). [isolationLevel] is honoured only when a new
+  /// transaction is opened.
+  Future<T> runTransaction<T>(
+    Future<T> Function(BaseExecutor) callback, {
+    IsolationLevel? isolationLevel,
+  });
+
+  /// Close the underlying connection. No-op when inside a transaction (a
+  /// transaction does not own the adapter's connection lifecycle).
+  Future<void> dispose();
 }
 
 /// Executes Prisma queries against a database adapter.
@@ -620,7 +636,15 @@ class QueryExecutor with ResultSetConverter implements BaseExecutor {
     }
   }
 
+  @override
+  Future<T> runTransaction<T>(
+    Future<T> Function(BaseExecutor) callback, {
+    IsolationLevel? isolationLevel,
+  }) =>
+      executeInTransaction<T>(callback, isolationLevel: isolationLevel);
+
   /// Close the adapter connection.
+  @override
   Future<void> dispose() async {
     await adapter.dispose();
   }
@@ -756,5 +780,21 @@ class TransactionExecutor with ResultSetConverter implements BaseExecutor {
     if (count is String) return int.parse(count);
 
     return 0;
+  }
+
+  @override
+  Future<T> runTransaction<T>(
+    Future<T> Function(BaseExecutor) callback, {
+    IsolationLevel? isolationLevel,
+  }) async {
+    // Already inside a transaction: reuse the ambient one (nested
+    // $transaction flattens). PostgreSQL has no true nested transactions and
+    // the isolation level cannot change mid-transaction, so it is ignored.
+    return callback(this);
+  }
+
+  @override
+  Future<void> dispose() async {
+    // No-op: the transaction does not own the adapter's connection lifecycle.
   }
 }

--- a/lib/src/runtime/query/relation_compiler.dart
+++ b/lib/src/runtime/query/relation_compiler.dart
@@ -97,6 +97,10 @@ class IncludedRelation {
 
 /// Compiles Prisma include/select into SQL JOINs.
 class RelationCompiler {
+  /// Maximum nested-include depth. Guards against pathological or cyclic
+  /// include graphs that would otherwise emit an unbounded JOIN chain.
+  static const int maxIncludeDepth = 5;
+
   final SchemaRegistry _schema;
   final String _provider;
 
@@ -187,6 +191,7 @@ class RelationCompiler {
         parentAlias: baseAlias,
         includeValue: relationValue,
         aliases: aliases,
+        depth: 1,
       );
 
       if (result != null) {
@@ -224,7 +229,14 @@ class RelationCompiler {
     required String parentAlias,
     required dynamic includeValue,
     required Map<String, ColumnAlias> aliases,
+    required int depth,
   }) {
+    if (depth > maxIncludeDepth) {
+      throw StateError(
+        'Nested include depth exceeds the limit of $maxIncludeDepth at '
+        '"$relationName". Reduce nesting or split into separate queries.',
+      );
+    }
     final targetModel = _schema.getModel(relation.targetModel);
     if (targetModel == null) return null;
 
@@ -302,6 +314,7 @@ class RelationCompiler {
               parentAlias: tableAlias,
               includeValue: nested.value,
               aliases: aliases,
+              depth: depth + 1,
             );
             if (nestedResult != null) {
               nestedIncludes.add(nestedResult.includedRelation);

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -193,6 +193,9 @@ class SqlCompiler {
       case 'createMany':
         return _compileCreateManyQuery(query);
 
+      case 'createManyAndReturn':
+        return _compileCreateManyQuery(query, andReturn: true);
+
       case 'update':
         return _compileUpdateQuery(query);
 
@@ -542,8 +545,13 @@ class SqlCompiler {
   }
 
   /// Compile a CREATE MANY query.
-  SqlQuery _compileCreateManyQuery(JsonQuery query) {
+  ///
+  /// [andReturn] appends `RETURNING *` (Postgres/Supabase) for
+  /// `createManyAndReturn`. `skipDuplicates: true` emits `ON CONFLICT DO
+  /// NOTHING` so pre-existing rows are silently ignored.
+  SqlQuery _compileCreateManyQuery(JsonQuery query, {bool andReturn = false}) {
     final args = query.args.arguments ?? {};
+    final skipDuplicates = args['skipDuplicates'] == true;
 
     // Handle both direct list and wrapped {'data': [...]} format
     // The delegate_generator wraps data in {'data': ...}, but sql_compiler
@@ -583,12 +591,15 @@ class SqlCompiler {
       valueSets.add('(${placeholders.join(', ')})');
     }
 
-    final sql = 'INSERT INTO ${_quoteIdentifier(tableName)} '
+    final isPg = provider == 'postgresql' || provider == 'supabase';
+    final sql = StringBuffer('INSERT INTO ${_quoteIdentifier(tableName)} '
         '(${columns.join(', ')}) '
-        'VALUES ${valueSets.join(', ')}';
+        'VALUES ${valueSets.join(', ')}');
+    if (skipDuplicates) sql.write(' ON CONFLICT DO NOTHING');
+    if (andReturn && isPg) sql.write(' RETURNING *');
 
     return SqlQuery(
-      sql: sql,
+      sql: sql.toString(),
       args: values,
       argTypes: types,
     );
@@ -626,10 +637,31 @@ class SqlCompiler {
     var paramIndex = 1;
 
     for (final entry in data.entries) {
+      final col =
+          _quoteIdentifier(_resolveColumnName(query.modelName, entry.key));
+
+      // Atomic numeric update ops: {increment/decrement/multiply/divide/set: n}.
+      final atomic = _atomicUpdateOp(entry.value);
+      if (atomic != null) {
+        final (op, operand) = atomic;
+        if (op == 'set') {
+          setClauses.add('$col = ${_placeholder(paramIndex++)}');
+        } else {
+          const sqlOp = {
+            'increment': '+',
+            'decrement': '-',
+            'multiply': '*',
+            'divide': '/',
+          };
+          setClauses.add('$col = $col ${sqlOp[op]} ${_placeholder(paramIndex++)}');
+        }
+        values.add(operand);
+        types.add(_inferArgType(operand));
+        continue;
+      }
+
       // Resolve @map-ed Dart field names to column names
-      setClauses.add(
-          '${_quoteIdentifier(_resolveColumnName(query.modelName, entry.key))}'
-          ' = ${_placeholder(paramIndex++)}');
+      setClauses.add('$col = ${_placeholder(paramIndex++)}');
       values.add(entry.value);
       types.add(_inferArgType(entry.value));
     }
@@ -658,6 +690,16 @@ class SqlCompiler {
       args: values,
       argTypes: types,
     );
+  }
+
+  /// Recognize a Prisma atomic numeric update op (`{increment: n}`, etc.).
+  /// Returns (operator, operand) or null when the value is a plain assignment.
+  (String, dynamic)? _atomicUpdateOp(dynamic value) {
+    if (value is! Map<String, dynamic> || value.length != 1) return null;
+    const ops = {'increment', 'decrement', 'multiply', 'divide', 'set'};
+    final key = value.keys.first;
+    if (!ops.contains(key)) return null;
+    return (key, value.values.first);
   }
 
   /// Compile an UPDATE MANY query.

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -1833,6 +1833,11 @@ RETURNING *
     'notInOrNull',
     'inOrNull',
     'equalsOrNull',
+    // scalar-list (array column) operators
+    'has',
+    'hasEvery',
+    'hasSome',
+    'isEmpty',
   };
 
   /// Validate that a Map filter value contains only known operators.
@@ -2194,6 +2199,52 @@ RETURNING *
               values.add(op.value);
               types.add(_inferArgType(op.value));
               break;
+
+            // ==================== Scalar-list (array) Operators ==============
+            // PostgreSQL array columns (String[]/enum[]/Int[]). Element type
+            // is inferred from the column, so ARRAY[...] needs no cast.
+
+            case 'has':
+              // value is an element of the array column
+              conditions
+                  .add('${_placeholder(paramIndex++)} = ANY($columnName)');
+              values.add(op.value);
+              types.add(_inferArgType(op.value));
+              break;
+
+            case 'hasSome':
+              final some = (op.value as List?) ?? const [];
+              if (some.isEmpty) {
+                conditions.add('(1=0)'); // overlaps nothing
+              } else {
+                final ph = List.generate(
+                    some.length, (_) => _placeholder(paramIndex++));
+                conditions.add('$columnName && ARRAY[${ph.join(', ')}]');
+                values.addAll(some);
+                types.addAll(some.map(_inferArgType));
+              }
+              break;
+
+            case 'hasEvery':
+              final every = (op.value as List?) ?? const [];
+              if (every.isEmpty) {
+                conditions.add('(1=1)'); // contains all of nothing
+              } else {
+                final ph = List.generate(
+                    every.length, (_) => _placeholder(paramIndex++));
+                conditions.add('$columnName @> ARRAY[${ph.join(', ')}]');
+                values.addAll(every);
+                types.addAll(every.map(_inferArgType));
+              }
+              break;
+
+            case 'isEmpty':
+              final wantEmpty = op.value == true;
+              conditions.add(wantEmpty
+                  ? 'COALESCE(cardinality($columnName), 0) = 0'
+                  : 'COALESCE(cardinality($columnName), 0) > 0');
+              break;
+
             default:
               // This should not be reached if _knownScalarOperators is in sync
               // with this switch statement, but serves as a safeguard.

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -7,6 +7,8 @@
 /// via FFI, but this pure Dart version is easier to debug and works everywhere.
 library;
 
+import 'dart:convert';
+
 import 'package:prisma_flutter_connector/src/runtime/adapters/types.dart';
 import 'package:prisma_flutter_connector/src/runtime/query/json_protocol.dart';
 import 'package:prisma_flutter_connector/src/runtime/query/relation_compiler.dart';
@@ -340,6 +342,29 @@ class SqlCompiler {
       startIndex: computedArgs.length + 1,
     );
 
+    // Cursor pagination (#69): derive a keyset predicate from `cursor` + the
+    // orderBy sequence and AND it onto the WHERE clause. Inclusive of the
+    // cursor row (use `skip: 1` to exclude it, matching Prisma semantics).
+    var effectiveWhere = whereClause;
+    var cursorArgs = <dynamic>[];
+    var cursorTypes = <ArgType>[];
+    final cursor = args['cursor'];
+    if (cursor is Map<String, dynamic> && cursor.isNotEmpty) {
+      final (cc, cv, ct) = _buildCursorClause(
+        cursor,
+        args['orderBy'],
+        modelName: query.modelName,
+        baseAlias: needsAlias ? baseAlias : null,
+        startIndex: computedArgs.length + 1 + whereArgs.length,
+      );
+      if (cc.isNotEmpty) {
+        effectiveWhere =
+            effectiveWhere.isEmpty ? cc : '($effectiveWhere) AND ($cc)';
+        cursorArgs = cv;
+        cursorTypes = ct;
+      }
+    }
+
     // Build ORDER BY clause
     // Pass baseAlias when JOINs are present to disambiguate column names
     final orderBy = args['orderBy'];
@@ -385,8 +410,8 @@ class SqlCompiler {
           'SELECT $distinctClause$selectClause FROM ${_quoteIdentifier(tableName)}');
     }
 
-    if (whereClause.isNotEmpty) {
-      sql.write(' WHERE $whereClause');
+    if (effectiveWhere.isNotEmpty) {
+      sql.write(' WHERE $effectiveWhere');
     }
 
     if (orderByClause.isNotEmpty) {
@@ -403,9 +428,9 @@ class SqlCompiler {
       sql.write(' OFFSET $skip');
     }
 
-    // Combine computed field args (first) with WHERE args (second)
-    final allArgs = [...computedArgs, ...whereArgs];
-    final allTypes = [...computedTypes, ...whereTypes];
+    // Combine computed field args (first), WHERE args, then cursor args.
+    final allArgs = [...computedArgs, ...whereArgs, ...cursorArgs];
+    final allTypes = [...computedTypes, ...whereTypes, ...cursorTypes];
 
     // Collect computed field names for preservation during relation deserialization
     final computedFieldNamesList =
@@ -2051,6 +2076,19 @@ RETURNING *
           : _quoteIdentifier(resolvedField);
 
       if (value is Map<String, dynamic>) {
+        // JSON(B) column filters (#69): detected by a `path` key or a
+        // JSON-specific operator. Handled before scalar validation.
+        if (_isJsonFilter(value)) {
+          final (jc, jv, jt) = _buildJsonCondition(columnName, value, paramIndex);
+          if (jc.isNotEmpty) {
+            conditions.add(jc);
+            values.addAll(jv);
+            types.addAll(jt);
+            paramIndex += jv.length;
+          }
+          continue;
+        }
+
         // Validate that all keys are known operators before processing
         // This catches invalid patterns early instead of generating bad SQL
         _validateScalarFilterOperators(field, value, modelName);
@@ -2745,6 +2783,185 @@ WHERE $joinTable.$joinColumn = $parentRef.$pkCol''';
   /// Check if the database provider supports NULLS FIRST/LAST ordering.
   bool _supportsNullsOrdering() {
     return provider == 'postgresql' || provider == 'supabase';
+  }
+
+  static const _jsonOnlyKeys = {
+    'path',
+    'string_contains',
+    'string_starts_with',
+    'string_ends_with',
+    'array_contains',
+  };
+
+  /// A filter map targets a JSON(B) column when it carries a `path` or any
+  /// JSON-specific operator.
+  bool _isJsonFilter(Map<String, dynamic> value) =>
+      value.keys.any(_jsonOnlyKeys.contains);
+
+  /// Build a PostgreSQL JSON(B) condition from a Prisma-style JSON filter.
+  ///
+  /// `path` (a list of keys) navigates into the column via `#>`/`#>>`; the
+  /// remaining operators compare the addressed value. Without a `path` the
+  /// operators apply to the column itself.
+  (String, List<dynamic>, List<ArgType>) _buildJsonCondition(
+    String columnName,
+    Map<String, dynamic> filter,
+    int startIndex,
+  ) {
+    if (provider != 'postgresql' && provider != 'supabase') {
+      throw UnsupportedError(
+        'JSON filters are only supported on PostgreSQL/Supabase.',
+      );
+    }
+
+    var paramIndex = startIndex;
+    final values = <dynamic>[];
+    final types = <ArgType>[];
+    final parts = <String>[];
+
+    // Address the target: `col #> '{a,b}'` (jsonb) or `col #>> '{a,b}'` (text).
+    final path = filter['path'];
+    String pathLiteral = '';
+    if (path is List && path.isNotEmpty) {
+      pathLiteral = "'{${path.join(',')}}'";
+    }
+    String jsonbExpr() =>
+        pathLiteral.isEmpty ? columnName : '$columnName #> $pathLiteral';
+    String textExpr() => pathLiteral.isEmpty
+        ? '$columnName #>> \'{}\''
+        : '$columnName #>> $pathLiteral';
+
+    for (final entry in filter.entries) {
+      switch (entry.key) {
+        case 'path':
+          break; // addressing only
+        case 'equals':
+          parts.add('${jsonbExpr()} = ${_placeholder(paramIndex++)}::jsonb');
+          values.add(jsonEncode(entry.value));
+          types.add(ArgType.string);
+          break;
+        case 'string_contains':
+          parts.add('${textExpr()} LIKE ${_placeholder(paramIndex++)}');
+          values.add('%${entry.value}%');
+          types.add(ArgType.string);
+          break;
+        case 'string_starts_with':
+          parts.add('${textExpr()} LIKE ${_placeholder(paramIndex++)}');
+          values.add('${entry.value}%');
+          types.add(ArgType.string);
+          break;
+        case 'string_ends_with':
+          parts.add('${textExpr()} LIKE ${_placeholder(paramIndex++)}');
+          values.add('%${entry.value}');
+          types.add(ArgType.string);
+          break;
+        case 'array_contains':
+          parts.add('${jsonbExpr()} @> ${_placeholder(paramIndex++)}::jsonb');
+          values.add(jsonEncode(entry.value));
+          types.add(ArgType.string);
+          break;
+        case 'lt':
+        case 'lte':
+        case 'gt':
+        case 'gte':
+          const ops = {'lt': '<', 'lte': '<=', 'gt': '>', 'gte': '>='};
+          parts.add(
+              '(${textExpr()})::numeric ${ops[entry.key]} ${_placeholder(paramIndex++)}');
+          values.add(entry.value);
+          types.add(_inferArgType(entry.value));
+          break;
+        default:
+          throw ArgumentError(
+            'Unknown JSON filter operator "${entry.key}".',
+          );
+      }
+    }
+
+    final clause = parts.length == 1 ? parts.first : '(${parts.join(' AND ')})';
+    return (clause, values, types);
+  }
+
+  /// Normalize `orderBy` (Map or List<Map>) into an ordered list of
+  /// (fieldName, isDescending) pairs, preserving declaration order.
+  List<(String, bool)> _normalizeOrderBy(dynamic orderBy) {
+    final result = <(String, bool)>[];
+    void addMap(Map<String, dynamic> m) {
+      for (final e in m.entries) {
+        final desc = e.value is Map
+            ? (e.value as Map)['sort'] == 'desc'
+            : e.value == 'desc';
+        result.add((e.key, desc));
+      }
+    }
+
+    if (orderBy is List) {
+      for (final item in orderBy) {
+        if (item is Map<String, dynamic>) addMap(item);
+      }
+    } else if (orderBy is Map<String, dynamic>) {
+      addMap(orderBy);
+    }
+    return result;
+  }
+
+  /// Build a keyset predicate for cursor pagination from the `cursor` value and
+  /// the `orderBy` sequence. Inclusive of the cursor row (Prisma pairs this with
+  /// `skip: 1` to exclude it). Fields are ordered by `orderBy`; any cursor field
+  /// absent from `orderBy` is appended ascending so it still bounds the scan.
+  ///
+  /// For orderBy `[a ASC, b DESC]` and cursor `{a, b}` this yields the canonical
+  /// expansion `(a > ?) OR (a = ? AND b <= ?)`.
+  (String, List<dynamic>, List<ArgType>) _buildCursorClause(
+    Map<String, dynamic> cursor,
+    dynamic orderBy, {
+    String? modelName,
+    String? baseAlias,
+    int startIndex = 1,
+  }) {
+    // Order the cursor fields by the orderBy sequence; append leftovers asc.
+    final ordered = <(String, bool)>[];
+    for (final (field, desc) in _normalizeOrderBy(orderBy)) {
+      if (cursor.containsKey(field)) ordered.add((field, desc));
+    }
+    for (final field in cursor.keys) {
+      if (!ordered.any((o) => o.$1 == field)) ordered.add((field, false));
+    }
+    if (ordered.isEmpty) return ('', const [], const []);
+
+    String col(String field) {
+      final resolved = _resolveColumnName(modelName, field);
+      return baseAlias != null
+          ? '"$baseAlias".${_quoteIdentifier(resolved)}'
+          : _quoteIdentifier(resolved);
+    }
+
+    var paramIndex = startIndex;
+    final values = <dynamic>[];
+    final types = <ArgType>[];
+    final disjuncts = <String>[];
+
+    for (var i = 0; i < ordered.length; i++) {
+      final terms = <String>[];
+      // Equalities for all fields before position i.
+      for (var j = 0; j < i; j++) {
+        terms.add('${col(ordered[j].$1)} = ${_placeholder(paramIndex++)}');
+        values.add(cursor[ordered[j].$1]);
+        types.add(_inferArgType(cursor[ordered[j].$1]));
+      }
+      // Comparison at position i: strict except the final field is inclusive.
+      final desc = ordered[i].$2;
+      final isLast = i == ordered.length - 1;
+      final op = desc ? (isLast ? '<=' : '<') : (isLast ? '>=' : '>');
+      terms.add('${col(ordered[i].$1)} $op ${_placeholder(paramIndex++)}');
+      values.add(cursor[ordered[i].$1]);
+      types.add(_inferArgType(cursor[ordered[i].$1]));
+
+      disjuncts.add(terms.length == 1 ? terms.first : '(${terms.join(' AND ')})');
+    }
+
+    final clause =
+        disjuncts.length == 1 ? disjuncts.first : '(${disjuncts.join(' OR ')})';
+    return (clause, values, types);
   }
 
   /// Get placeholder syntax for the database provider.

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -1744,6 +1744,9 @@ RETURNING *
     if (value.containsKey('some')) return 'some';
     if (value.containsKey('every')) return 'every';
     if (value.containsKey('none')) return 'none';
+    // to-one relation operators
+    if (value.containsKey('is')) return 'is';
+    if (value.containsKey('isNot')) return 'isNot';
     return null;
   }
 
@@ -1908,7 +1911,28 @@ RETURNING *
         final relOperator = _detectRelationOperator(value);
 
         if (relation != null && relOperator != null) {
-          final whereCondition = value[relOperator];
+          final rawCondition = value[relOperator];
+          // to-one relations use is/isNot; to-many use some/every/none.
+          final isToOne = relation.type == RelationType.manyToOne ||
+              relation.type == RelationType.oneToOne;
+          if ((relOperator == 'is' || relOperator == 'isNot') && !isToOne) {
+            throw ArgumentError(
+              'Operator "$relOperator" on relation "$field" of model '
+              '"$modelName" is only valid for to-one relations. Use '
+              'some(), every(), or none() for to-many relations.',
+            );
+          }
+          // Map is/isNot (honouring null-target semantics) onto the
+          // some/none EXISTS builders: is:{cond}->EXISTS, is:null->NOT EXISTS,
+          // isNot:{cond}->NOT EXISTS, isNot:null->EXISTS.
+          final String effectiveOp;
+          if (relOperator == 'is') {
+            effectiveOp = rawCondition == null ? 'none' : 'some';
+          } else if (relOperator == 'isNot') {
+            effectiveOp = rawCondition == null ? 'some' : 'none';
+          } else {
+            effectiveOp = relOperator;
+          }
           // Use baseAlias if available, otherwise fall back to parentAlias
           // This ensures relation filters use the correct table alias (e.g., 't0')
           final effectiveParentAlias = baseAlias ?? parentAlias;
@@ -1917,9 +1941,9 @@ RETURNING *
             parentAlias: effectiveParentAlias,
             relationName: field,
             relation: relation,
-            operator: relOperator,
+            operator: effectiveOp,
             whereCondition:
-                whereCondition is Map<String, dynamic> ? whereCondition : {},
+                rawCondition is Map<String, dynamic> ? rawCondition : {},
             startIndex: paramIndex,
           );
           conditions.add(clause);

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -421,7 +421,12 @@ class SqlCompiler {
       sql.write(' ORDER BY $orderByClause');
     }
 
-    if (single) {
+    // `single` (findUnique/findFirst) normally caps at one row — but a to-many
+    // include multiplies rows via JOIN, so LIMIT 1 would truncate the child
+    // collection. Suppress it then and let the deserializer group + the caller
+    // take the first parent. To-one-only includes stay capped.
+    final singleWithToMany = single && _includeHasToMany(query.modelName, include);
+    if (single && !singleWithToMany) {
       sql.write(' LIMIT 1');
     } else if (take != null) {
       sql.write(' LIMIT $take');
@@ -472,6 +477,50 @@ class SqlCompiler {
     return include.isEmpty ? null : include;
   }
 
+  /// Fill in `@default(uuid()/cuid()/now())` and `@updatedAt` values not
+  /// supplied by the caller. Shared by `create` and `createMany`.
+  void _autofillCreateDefaults(Map<String, dynamic> data, ModelSchema? model) {
+    if (model == null) return;
+    final isPg = provider == 'postgresql' || provider == 'supabase';
+    for (final field in model.fields.values) {
+      if (data.containsKey(field.name) || data.containsKey(field.columnName)) {
+        continue;
+      }
+      if (field.defaultValue == 'uuid()' || field.defaultValue == 'cuid()') {
+        if (isPg) data[field.name] = const _RawSql('gen_random_uuid()');
+      } else if (field.defaultValue == 'now()' || field.isUpdatedAt) {
+        data[field.name] = isPg
+            ? const _RawSql('NOW()')
+            : DateTime.now().toUtc().toIso8601String();
+      }
+    }
+  }
+
+  /// Whether an `include` tree contains any to-many relation (which multiplies
+  /// JOIN rows). Recurses into nested includes.
+  bool _includeHasToMany(String modelName, Map<String, dynamic>? include) {
+    if (include == null || include.isEmpty) return false;
+    final effectiveSchema = schema ?? schemaRegistry;
+    for (final entry in include.entries) {
+      if (entry.value == false) continue;
+      final relation = effectiveSchema.getRelation(modelName, entry.key);
+      if (relation == null) continue;
+      if (relation.type == RelationType.oneToMany ||
+          relation.type == RelationType.manyToMany) {
+        return true;
+      }
+      // Recurse into nested include on a to-one relation.
+      final v = entry.value;
+      if (v is Map<String, dynamic> && v['include'] is Map<String, dynamic>) {
+        if (_includeHasToMany(
+            relation.targetModel, v['include'] as Map<String, dynamic>)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   /// Compile a CREATE query.
   SqlQuery _compileCreateQuery(JsonQuery query) {
     final args = query.args.arguments ?? {};
@@ -485,26 +534,7 @@ class SqlCompiler {
     // @updatedAt values. @updatedAt columns are NOT NULL with no database
     // default — Prisma clients supply the timestamp on every create.
     final effectiveSchema = schema ?? schemaRegistry;
-    final model = effectiveSchema.getModel(query.modelName);
-    if (model != null) {
-      for (final field in model.fields.values) {
-        if (data.containsKey(field.name) ||
-            data.containsKey(field.columnName)) {
-          continue;
-        }
-        if (field.defaultValue == 'uuid()' || field.defaultValue == 'cuid()') {
-          if (provider == 'postgresql' || provider == 'supabase') {
-            data[field.name] = const _RawSql('gen_random_uuid()');
-          }
-        } else if (field.defaultValue == 'now()' || field.isUpdatedAt) {
-          if (provider == 'postgresql' || provider == 'supabase') {
-            data[field.name] = const _RawSql('NOW()');
-          } else {
-            data[field.name] = DateTime.now().toUtc().toIso8601String();
-          }
-        }
-      }
-    }
+    _autofillCreateDefaults(data, effectiveSchema.getModel(query.modelName));
 
     final tableName = _resolveTableName(query.modelName);
     final columns = <String>[];
@@ -567,9 +597,20 @@ class SqlCompiler {
     }
 
     final tableName = _resolveTableName(query.modelName);
-    final firstRow = dataList.first as Map<String, dynamic>;
+
+    // Autofill @default(uuid()/now())/@updatedAt per row (as `create` does),
+    // then emit a uniform column list. Prisma requires uniform-shaped rows.
+    final model = (schema ?? schemaRegistry).getModel(query.modelName);
+    final rows = dataList
+        .map((r) => Map<String, dynamic>.from(r as Map<String, dynamic>))
+        .toList();
+    for (final r in rows) {
+      _autofillCreateDefaults(r, model);
+    }
+
+    final fieldOrder = rows.first.keys.toList();
     // Resolve @map-ed Dart field names to column names
-    final columns = firstRow.keys
+    final columns = fieldOrder
         .map((k) => _quoteIdentifier(_resolveColumnName(query.modelName, k)))
         .toList();
 
@@ -578,16 +619,18 @@ class SqlCompiler {
     final types = <ArgType>[];
 
     var paramIndex = 1;
-    for (final row in dataList) {
-      final rowData = row as Map<String, dynamic>;
+    for (final row in rows) {
       final placeholders = <String>[];
-
-      for (final value in rowData.values) {
-        placeholders.add(_placeholder(paramIndex++));
-        values.add(value);
-        types.add(_inferArgType(value));
+      for (final field in fieldOrder) {
+        final value = row[field];
+        if (value is _RawSql) {
+          placeholders.add(value.sql);
+        } else {
+          placeholders.add(_placeholder(paramIndex++));
+          values.add(value);
+          types.add(_inferArgType(value));
+        }
       }
-
       valueSets.add('(${placeholders.join(', ')})');
     }
 
@@ -1262,7 +1305,20 @@ RETURNING *
                 relation.type == RelationType.manyToOne) &&
             (value as Map<String, dynamic>).containsKey('connect')) {
           final connectData = value['connect'] as Map<String, dynamic>;
-          cleanData[relation.foreignKey] = connectData.values.first;
+          // Inject the FK keyed by its Dart field name and drop any
+          // user-supplied FK (field or column) so it isn't emitted twice.
+          final fkKey = effectiveSchema
+                  .getModel(query.modelName)
+                  ?.fields
+                  .values
+                  .where((f) => f.columnName == relation.foreignKey)
+                  .map((f) => f.name)
+                  .firstOrNull ??
+              relation.foreignKey;
+          cleanData
+            ..remove(fkKey)
+            ..remove(relation.foreignKey);
+          cleanData[fkKey] = connectData.values.first;
         }
         // A belongsTo `create` (this row owns the FK) requires creating the
         // parent first and inlining its generated id — parent-first ordering
@@ -1371,9 +1427,21 @@ RETURNING *
               ? List<Map<String, dynamic>>.from(creates)
               : [creates as Map<String, dynamic>];
           final targetModel = effectiveSchema.getModel(relation.targetModel);
+          // The relation's foreignKey is a COLUMN name; child data uses Dart
+          // FIELD names. Resolve the FK field so we inject exactly one FK entry
+          // (keyed by field) and strip any user-supplied value under either the
+          // field or column name — otherwise both resolve to the same column
+          // and Postgres rejects "column specified more than once".
+          final fkField = targetModel?.fields.values
+              .where((f) => f.columnName == relation.foreignKey)
+              .map((f) => f.name)
+              .firstOrNull;
+          final fkKey = fkField ?? relation.foreignKey;
           for (final createData in createList) {
-            final childData = Map<String, dynamic>.from(createData);
-            childData[relation.foreignKey] = parentId;
+            final childData = Map<String, dynamic>.from(createData)
+              ..remove(relation.foreignKey)
+              ..remove(fkKey);
+            childData[fkKey] = parentId;
             if (targetModel != null) {
               for (final field in targetModel.fields.values) {
                 if (childData.containsKey(field.name)) continue;

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -732,6 +732,9 @@ class SqlCompiler {
     final agg = args['_aggregate'] as Map<String, dynamic>? ?? {};
 
     final tableName = _resolveTableName(query.modelName);
+    // Resolve @map-ed Dart field names to DB columns for function args;
+    // aliases keep the Dart field name so result keys stay stable.
+    String col(Object f) => _resolveColumnName(query.modelName, f.toString());
     final functions = <String>[];
     final filterValues = <dynamic>[];
     final filterTypes = <ArgType>[];
@@ -754,7 +757,7 @@ class SqlCompiler {
       for (final field in countFields.keys) {
         if (countFields[field] == true) {
           functions.add(
-            'COUNT(${_quoteIdentifier(field)}) AS "_count_$field"',
+            'COUNT(${_quoteIdentifier(col(field))}) AS "_count_$field"',
           );
         }
       }
@@ -788,7 +791,8 @@ class SqlCompiler {
       final avgFields = agg['_avg'] as Map<String, dynamic>;
       for (final field in avgFields.keys) {
         if (avgFields[field] == true) {
-          functions.add('AVG(${_quoteIdentifier(field)}) AS "_avg_$field"');
+          functions
+              .add('AVG(${_quoteIdentifier(col(field))}) AS "_avg_$field"');
         }
       }
     }
@@ -810,7 +814,7 @@ class SqlCompiler {
             );
             filterParamIndex += filter.length;
             functions.add(
-              'AVG(${_quoteIdentifier(field)}) FILTER (WHERE $filterClause) AS ${_quoteIdentifier(alias)}',
+              'AVG(${_quoteIdentifier(col(field))}) FILTER (WHERE $filterClause) AS ${_quoteIdentifier(alias)}',
             );
           }
         }
@@ -822,7 +826,8 @@ class SqlCompiler {
       final sumFields = agg['_sum'] as Map<String, dynamic>;
       for (final field in sumFields.keys) {
         if (sumFields[field] == true) {
-          functions.add('SUM(${_quoteIdentifier(field)}) AS "_sum_$field"');
+          functions
+              .add('SUM(${_quoteIdentifier(col(field))}) AS "_sum_$field"');
         }
       }
     }
@@ -832,7 +837,8 @@ class SqlCompiler {
       final minFields = agg['_min'] as Map<String, dynamic>;
       for (final field in minFields.keys) {
         if (minFields[field] == true) {
-          functions.add('MIN(${_quoteIdentifier(field)}) AS "_min_$field"');
+          functions
+              .add('MIN(${_quoteIdentifier(col(field))}) AS "_min_$field"');
         }
       }
     }
@@ -842,7 +848,8 @@ class SqlCompiler {
       final maxFields = agg['_max'] as Map<String, dynamic>;
       for (final field in maxFields.keys) {
         if (maxFields[field] == true) {
-          functions.add('MAX(${_quoteIdentifier(field)}) AS "_max_$field"');
+          functions
+              .add('MAX(${_quoteIdentifier(col(field))}) AS "_max_$field"');
         }
       }
     }

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -924,9 +924,19 @@ class SqlCompiler {
     // Build SELECT clause with group by fields and aggregations
     final selectParts = <String>[];
 
-    // Add group by fields to SELECT
+    // Resolve a Dart field name to its DB column (pass-through for names
+    // that are already columns), for @map-ed fields in by/aggregates.
+    String col(Object field) =>
+        _resolveColumnName(query.modelName, field.toString());
+
+    // Add group by fields to SELECT, aliasing @map-ed columns back to the
+    // Dart field name so the result map stays keyed by the field.
     for (final field in groupByFields) {
-      selectParts.add(_quoteIdentifier(field.toString()));
+      final f = field.toString();
+      final c = col(f);
+      selectParts.add(c == f
+          ? _quoteIdentifier(c)
+          : '${_quoteIdentifier(c)} AS ${_quoteIdentifier(f)}');
     }
 
     // Add aggregation functions
@@ -936,25 +946,25 @@ class SqlCompiler {
     if (agg['_avg'] is Map) {
       for (final field in (agg['_avg'] as Map).keys) {
         selectParts
-            .add('AVG(${_quoteIdentifier(field.toString())}) AS "_avg_$field"');
+            .add('AVG(${_quoteIdentifier(col(field))}) AS "_avg_$field"');
       }
     }
     if (agg['_sum'] is Map) {
       for (final field in (agg['_sum'] as Map).keys) {
         selectParts
-            .add('SUM(${_quoteIdentifier(field.toString())}) AS "_sum_$field"');
+            .add('SUM(${_quoteIdentifier(col(field))}) AS "_sum_$field"');
       }
     }
     if (agg['_min'] is Map) {
       for (final field in (agg['_min'] as Map).keys) {
         selectParts
-            .add('MIN(${_quoteIdentifier(field.toString())}) AS "_min_$field"');
+            .add('MIN(${_quoteIdentifier(col(field))}) AS "_min_$field"');
       }
     }
     if (agg['_max'] is Map) {
       for (final field in (agg['_max'] as Map).keys) {
         selectParts
-            .add('MAX(${_quoteIdentifier(field.toString())}) AS "_max_$field"');
+            .add('MAX(${_quoteIdentifier(col(field))}) AS "_max_$field"');
       }
     }
 
@@ -972,7 +982,7 @@ class SqlCompiler {
 
     if (groupByFields.isNotEmpty) {
       sql.write(
-          ' GROUP BY ${groupByFields.map((f) => _quoteIdentifier(f.toString())).join(', ')}');
+          ' GROUP BY ${groupByFields.map((f) => _quoteIdentifier(col(f))).join(', ')}');
     }
 
     if (orderBy != null) {
@@ -1026,7 +1036,8 @@ class SqlCompiler {
     var paramIndex = 1;
 
     for (final entry in createData.entries) {
-      columns.add(_quoteIdentifier(entry.key));
+      columns.add(
+          _quoteIdentifier(_resolveColumnName(query.modelName, entry.key)));
       valuePlaceholders.add(_placeholder(paramIndex++));
       values.add(entry.value);
       types.add(_inferArgType(entry.value));
@@ -1036,11 +1047,16 @@ class SqlCompiler {
     final updateSetClauses = <String>[];
     for (final entry in updateData.entries) {
       updateSetClauses.add(
-        '${_quoteIdentifier(entry.key)} = ${_placeholder(paramIndex++)}',
+        '${_quoteIdentifier(_resolveColumnName(query.modelName, entry.key))}'
+        ' = ${_placeholder(paramIndex++)}',
       );
       values.add(entry.value);
       types.add(_inferArgType(entry.value));
     }
+
+    // @map-resolved conflict target columns
+    final conflictCols =
+        conflictKeys.map((k) => _resolveColumnName(query.modelName, k));
 
     // Generate SQL based on provider
     String sql;
@@ -1049,7 +1065,7 @@ class SqlCompiler {
       sql = '''
 INSERT INTO ${_quoteIdentifier(tableName)} (${columns.join(', ')})
 VALUES (${valuePlaceholders.join(', ')})
-ON CONFLICT (${conflictKeys.map(_quoteIdentifier).join(', ')})
+ON CONFLICT (${conflictCols.map(_quoteIdentifier).join(", ")})
 DO UPDATE SET ${updateSetClauses.join(', ')}
 RETURNING *
 '''
@@ -1068,7 +1084,7 @@ ON DUPLICATE KEY UPDATE ${updateSetClauses.join(', ')}
       sql = '''
 INSERT INTO ${_quoteIdentifier(tableName)} (${columns.join(', ')})
 VALUES (${valuePlaceholders.join(', ')})
-ON CONFLICT (${conflictKeys.map(_quoteIdentifier).join(', ')})
+ON CONFLICT (${conflictCols.map(_quoteIdentifier).join(", ")})
 DO UPDATE SET ${updateSetClauses.join(', ')}
 RETURNING *
 '''
@@ -2265,7 +2281,13 @@ RETURNING *
           inverseJoinColumn:
               _quoteIdentifier(relation.inverseJoinColumn ?? 'B'),
           parentRef: parentRef,
-          parentPk: relation.references.first,
+          // Resolve PK columns via the registry so @map-ed PKs work.
+          parentPk: parentModelSchema?.primaryKeys.isNotEmpty == true
+              ? parentModelSchema!.primaryKeys.first.columnName
+              : relation.references.first,
+          targetPk: targetModelSchema?.primaryKeys.isNotEmpty == true
+              ? targetModelSchema!.primaryKeys.first.columnName
+              : 'id',
           subWhere: subWhere,
         );
     }
@@ -2355,15 +2377,17 @@ RETURNING *
     required String inverseJoinColumn,
     required String parentRef,
     required String parentPk,
+    required String targetPk,
     required String subWhere,
   }) {
     final pkCol = _quoteIdentifier(parentPk);
+    final targetPkCol = _quoteIdentifier(targetPk);
 
     // Subquery joins through junction table to target table (with alias)
     // The alias allows nested relation filters to reference this table
     final joinClause = '''
 SELECT 1 FROM $joinTable
-INNER JOIN $targetTable AS $targetAlias ON $targetAlias."id" = $joinTable.$inverseJoinColumn
+INNER JOIN $targetTable AS $targetAlias ON $targetAlias.$targetPkCol = $joinTable.$inverseJoinColumn
 WHERE $joinTable.$joinColumn = $parentRef.$pkCol''';
 
     final fullCondition =

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -1016,8 +1016,10 @@ class SqlCompiler {
     final args = query.args.arguments ?? {};
     final where = args['where'] as Map<String, dynamic>? ?? {};
     final data = args['data'] as Map<String, dynamic>? ?? {};
-    final createData = data['create'] as Map<String, dynamic>? ?? {};
-    final updateData = data['update'] as Map<String, dynamic>? ?? {};
+    final createData = Map<String, dynamic>.from(
+        data['create'] as Map<String, dynamic>? ?? {});
+    final updateData = Map<String, dynamic>.from(
+        data['update'] as Map<String, dynamic>? ?? {});
 
     final tableName = _resolveTableName(query.modelName);
 
@@ -1026,6 +1028,36 @@ class SqlCompiler {
     if (conflictKeys.isEmpty) {
       throw ArgumentError(
           'Upsert requires at least one unique field in where clause');
+    }
+
+    // Autofill @default(uuid()/cuid()/now()) + @updatedAt on the CREATE arm,
+    // and refresh @updatedAt on the UPDATE arm — mirroring create/update.
+    final pgLike = provider == 'postgresql' || provider == 'supabase';
+    final model = (schema ?? schemaRegistry).getModel(query.modelName);
+    if (model != null) {
+      for (final field in model.fields.values) {
+        final present = createData.containsKey(field.name) ||
+            createData.containsKey(field.columnName);
+        if (!present) {
+          if (field.defaultValue == 'uuid()' ||
+              field.defaultValue == 'cuid()') {
+            if (pgLike) {
+              createData[field.name] = const _RawSql('gen_random_uuid()');
+            }
+          } else if (field.defaultValue == 'now()' || field.isUpdatedAt) {
+            createData[field.name] = pgLike
+                ? const _RawSql('NOW()')
+                : DateTime.now().toUtc().toIso8601String();
+          }
+        }
+        if (field.isUpdatedAt &&
+            !updateData.containsKey(field.name) &&
+            !updateData.containsKey(field.columnName)) {
+          updateData[field.name] = pgLike
+              ? const _RawSql('NOW()')
+              : DateTime.now().toUtc().toIso8601String();
+        }
+      }
     }
 
     // Build INSERT columns and values
@@ -1038,20 +1070,27 @@ class SqlCompiler {
     for (final entry in createData.entries) {
       columns.add(
           _quoteIdentifier(_resolveColumnName(query.modelName, entry.key)));
-      valuePlaceholders.add(_placeholder(paramIndex++));
-      values.add(entry.value);
-      types.add(_inferArgType(entry.value));
+      if (entry.value is _RawSql) {
+        valuePlaceholders.add((entry.value as _RawSql).sql);
+      } else {
+        valuePlaceholders.add(_placeholder(paramIndex++));
+        values.add(entry.value);
+        types.add(_inferArgType(entry.value));
+      }
     }
 
     // Build UPDATE SET clause
     final updateSetClauses = <String>[];
     for (final entry in updateData.entries) {
-      updateSetClauses.add(
-        '${_quoteIdentifier(_resolveColumnName(query.modelName, entry.key))}'
-        ' = ${_placeholder(paramIndex++)}',
-      );
-      values.add(entry.value);
-      types.add(_inferArgType(entry.value));
+      final col =
+          _quoteIdentifier(_resolveColumnName(query.modelName, entry.key));
+      if (entry.value is _RawSql) {
+        updateSetClauses.add('$col = ${(entry.value as _RawSql).sql}');
+      } else {
+        updateSetClauses.add('$col = ${_placeholder(paramIndex++)}');
+        values.add(entry.value);
+        types.add(_inferArgType(entry.value));
+      }
     }
 
     // @map-resolved conflict target columns

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -425,7 +425,8 @@ class SqlCompiler {
     // include multiplies rows via JOIN, so LIMIT 1 would truncate the child
     // collection. Suppress it then and let the deserializer group + the caller
     // take the first parent. To-one-only includes stay capped.
-    final singleWithToMany = single && _includeHasToMany(query.modelName, include);
+    final singleWithToMany =
+        single && _includeHasToMany(query.modelName, include);
     if (single && !singleWithToMany) {
       sql.write(' LIMIT 1');
     } else if (take != null) {
@@ -696,7 +697,8 @@ class SqlCompiler {
             'multiply': '*',
             'divide': '/',
           };
-          setClauses.add('$col = $col ${sqlOp[op]} ${_placeholder(paramIndex++)}');
+          setClauses
+              .add('$col = $col ${sqlOp[op]} ${_placeholder(paramIndex++)}');
         }
         values.add(operand);
         types.add(_inferArgType(operand));
@@ -2189,7 +2191,8 @@ RETURNING *
         // JSON(B) column filters (#69): detected by a `path` key or a
         // JSON-specific operator. Handled before scalar validation.
         if (_isJsonFilter(value)) {
-          final (jc, jv, jt) = _buildJsonCondition(columnName, value, paramIndex);
+          final (jc, jv, jt) =
+              _buildJsonCondition(columnName, value, paramIndex);
           if (jc.isNotEmpty) {
             conditions.add(jc);
             values.addAll(jv);
@@ -3066,7 +3069,8 @@ WHERE $joinTable.$joinColumn = $parentRef.$pkCol''';
       values.add(cursor[ordered[i].$1]);
       types.add(_inferArgType(cursor[ordered[i].$1]));
 
-      disjuncts.add(terms.length == 1 ? terms.first : '(${terms.join(' AND ')})');
+      disjuncts
+          .add(terms.length == 1 ? terms.first : '(${terms.join(' AND ')})');
     }
 
     final clause =

--- a/lib/src/runtime/query/sql_compiler.dart
+++ b/lib/src/runtime/query/sql_compiler.dart
@@ -1166,163 +1166,173 @@ RETURNING *
   ///     .build();
   /// ```
   CompiledMutation compileWithRelations(JsonQuery query) {
+    final mainQuery = _compileCleanMainMutation(query);
+    // Compile-time parent id (may be null on create-with-@default(uuid)); the
+    // atomic executor rebuilds these from the RETURNING row for correctness.
+    return CompiledMutation(
+      mainQuery: mainQuery,
+      relationMutations:
+          _buildRelationMutations(query, _compileTimeParentId(query)),
+    );
+  }
+
+  /// Build the main INSERT/UPDATE with relation-op keys stripped from `data`
+  /// (a 1:1 `connect` sets the FK on this row so it stays in the main query).
+  SqlQuery _compileCleanMainMutation(JsonQuery query) {
     final args = query.args.arguments ?? {};
     final data = args['data'] as Map<String, dynamic>? ?? {};
-
-    // Extract relation operations from data
-    final relationMutations = <SqlQuery>[];
-    final cleanData = <String, dynamic>{};
     final effectiveSchema = schema ?? schemaRegistry;
+    final cleanData = <String, dynamic>{};
 
     for (final entry in data.entries) {
       final value = entry.value;
-      if (value is Map<String, dynamic> &&
-          (value.containsKey('connect') ||
-              value.containsKey('disconnect') ||
-              value.containsKey('create'))) {
-        // This is a relation operation - look up the relation info
+      if (_isRelationOp(value)) {
         final relation =
             effectiveSchema.getRelation(query.modelName, entry.key);
-        if (relation != null && relation.type == RelationType.manyToMany) {
-          // Get primary key field name from schema (fallback to 'id' for compatibility)
-          final parentModel = effectiveSchema.getModel(query.modelName);
-          final parentPkFieldName = parentModel?.primaryKeys.isNotEmpty == true
-              ? parentModel!.primaryKeys.first.name
-              : 'id';
-
-          // Get the primary key value for the parent record
-          // For create, it's in the data; for update, it's in the where clause
-          String? parentId;
-          if (query.action == 'create') {
-            parentId = data[parentPkFieldName]?.toString();
-          } else if (query.action == 'update') {
-            final where = args['where'] as Map<String, dynamic>?;
-            parentId = where?[parentPkFieldName]?.toString();
-          }
-
-          if (parentId != null) {
-            // Compile connect operations
-            if (value.containsKey('connect')) {
-              final connectItems =
-                  _normalizeConnectDisconnect(value['connect']);
-              relationMutations.addAll(_compileConnectOperations(
-                parentId: parentId,
-                relation: relation,
-                connectItems: connectItems,
-                effectiveSchema: effectiveSchema,
-              ));
-            }
-
-            // Compile disconnect operations
-            if (value.containsKey('disconnect')) {
-              final disconnectItems =
-                  _normalizeConnectDisconnect(value['disconnect']);
-              relationMutations.addAll(_compileDisconnectOperations(
-                parentId: parentId,
-                relation: relation,
-                disconnectItems: disconnectItems,
-                effectiveSchema: effectiveSchema,
-              ));
-            }
-          }
-        } else if (relation != null &&
-            (relation.type == RelationType.oneToMany ||
-                relation.type == RelationType.oneToOne)) {
-          // 1:N or 1:1 nested writes: {create: [...]} or {connect: {id: ...}}
-          if (value.containsKey('create')) {
-            final creates = value['create'];
-            final createList = creates is List
-                ? List<Map<String, dynamic>>.from(creates)
-                : [creates as Map<String, dynamic>];
-
-            // Get parent PK field name
-            final parentModel = effectiveSchema.getModel(query.modelName);
-            final parentPkFieldName =
-                parentModel?.primaryKeys.isNotEmpty == true
-                    ? parentModel!.primaryKeys.first.name
-                    : 'id';
-
-            // Get parent ID from data (for create) or where (for update)
-            // Keep original type (String, int, etc.) for type-safe FK values
-            dynamic parentId;
-            if (query.action == 'create') {
-              parentId = data[parentPkFieldName];
-            } else if (query.action == 'update') {
-              final where = args['where'] as Map<String, dynamic>?;
-              parentId = where?[parentPkFieldName];
-            }
-
-            if (parentId != null) {
-              for (final createData in createList) {
-                // Inject the FK pointing to parent
-                final childData = Map<String, dynamic>.from(createData);
-                childData[relation.foreignKey] = parentId;
-
-                // Auto-generate UUID for child ID if the target model has @default(uuid())
-                final targetModel =
-                    effectiveSchema.getModel(relation.targetModel);
-                if (targetModel != null) {
-                  for (final field in targetModel.fields.values) {
-                    if (field.defaultValue == 'uuid()' &&
-                        !childData.containsKey(field.name)) {
-                      if (provider == 'postgresql' || provider == 'supabase') {
-                        childData[field.name] =
-                            const _RawSql('gen_random_uuid()');
-                      }
-                    } else if (field.defaultValue == 'now()' &&
-                        !childData.containsKey(field.name)) {
-                      if (provider == 'postgresql' || provider == 'supabase') {
-                        childData[field.name] = const _RawSql('NOW()');
-                      }
-                    }
-                  }
-                }
-
-                // Compile child INSERT
-                final targetTableName =
-                    targetModel?.tableName ?? relation.targetModel;
-                final childQuery = JsonQuery(
-                  modelName: targetTableName,
-                  action: 'create',
-                  args: JsonQueryArgs(arguments: {'data': childData}),
-                );
-                relationMutations.add(compile(childQuery));
-              }
-            }
-          }
-
-          if (value.containsKey('connect')) {
-            // 1:1 connect: set FK on parent row
-            final connectData = value['connect'] as Map<String, dynamic>;
-            final targetPkValue = connectData.values.first;
-            // The FK is on the current model → set it in cleanData
-            cleanData[relation.foreignKey] = targetPkValue;
-          }
+        // 1:1/N:1 connect where THIS row owns the FK → set it inline.
+        if (relation != null &&
+            (relation.type == RelationType.oneToOne ||
+                relation.type == RelationType.manyToOne) &&
+            (value as Map<String, dynamic>).containsKey('connect')) {
+          final connectData = value['connect'] as Map<String, dynamic>;
+          cleanData[relation.foreignKey] = connectData.values.first;
         }
-        // If relation is null, the field will be passed through and likely fail
-        // downstream with a more specific error about the unknown field
+        // A belongsTo `create` (this row owns the FK) requires creating the
+        // parent first and inlining its generated id — parent-first ordering
+        // the main-first engine can't express. Fail loudly instead of
+        // silently dropping the nested data.
+        else if (relation != null &&
+            relation.type == RelationType.manyToOne &&
+            (value as Map<String, dynamic>).containsKey('create')) {
+          throw UnsupportedError(
+            'Nested `create` on the to-one relation "${entry.key}" of '
+            '${query.modelName} is not supported: create the referenced '
+            '${relation.targetModel} first and use `connect`.',
+          );
+        }
+        // Other relation ops become separate mutations (not in main query).
       } else {
-        // Regular field - keep in clean data
         cleanData[entry.key] = value;
       }
     }
 
-    // Create modified query with clean data (no relation operations)
-    final cleanArgs = Map<String, dynamic>.from(args);
-    cleanArgs['data'] = cleanData;
-    final cleanQuery = JsonQuery(
+    final cleanArgs = Map<String, dynamic>.from(args)..['data'] = cleanData;
+    return compile(JsonQuery(
       modelName: query.modelName,
       action: query.action,
       args: JsonQueryArgs(arguments: cleanArgs),
-    );
+    ));
+  }
 
-    // Compile the main query
-    final mainQuery = compile(cleanQuery);
+  bool _isRelationOp(dynamic value) =>
+      value is Map<String, dynamic> &&
+      (value.containsKey('connect') ||
+          value.containsKey('disconnect') ||
+          value.containsKey('create'));
 
-    return CompiledMutation(
-      mainQuery: mainQuery,
-      relationMutations: relationMutations,
-    );
+  /// Parent PK value known at compile time (from `data` on create or `where`
+  /// on update); null when the id is DB-generated on create.
+  dynamic _compileTimeParentId(JsonQuery query) {
+    final args = query.args.arguments ?? {};
+    final data = args['data'] as Map<String, dynamic>? ?? {};
+    final effectiveSchema = schema ?? schemaRegistry;
+    final parentModel = effectiveSchema.getModel(query.modelName);
+    final pkField = parentModel?.primaryKeys.isNotEmpty == true
+        ? parentModel!.primaryKeys.first.name
+        : 'id';
+    if (query.action == 'update') {
+      return (args['where'] as Map<String, dynamic>?)?[pkField];
+    }
+    return data[pkField];
+  }
+
+  /// Rebuild relation mutations using the parent id from the main mutation's
+  /// RETURNING row — this fixes nested writes on a create whose PK is
+  /// DB-generated (`@default(uuid())`), where the id isn't known at compile.
+  List<SqlQuery> buildRelationMutationsFromResult(
+    JsonQuery query,
+    Map<String, dynamic>? resultRow,
+  ) {
+    final effectiveSchema = schema ?? schemaRegistry;
+    final parentModel = effectiveSchema.getModel(query.modelName);
+    final pkCol = parentModel?.primaryKeys.isNotEmpty == true
+        ? parentModel!.primaryKeys.first.columnName
+        : 'id';
+    final parentId = resultRow?[pkCol] ?? _compileTimeParentId(query);
+    return _buildRelationMutations(query, parentId);
+  }
+
+  /// Compile the m2m connect/disconnect and 1:N/1:1 `create` relation
+  /// mutations for [query] given the resolved [parentId].
+  List<SqlQuery> _buildRelationMutations(JsonQuery query, dynamic parentId) {
+    if (parentId == null) return const [];
+    final args = query.args.arguments ?? {};
+    final data = args['data'] as Map<String, dynamic>? ?? {};
+    final effectiveSchema = schema ?? schemaRegistry;
+    final mutations = <SqlQuery>[];
+
+    for (final entry in data.entries) {
+      final value = entry.value;
+      if (!_isRelationOp(value)) continue;
+      final relation = effectiveSchema.getRelation(query.modelName, entry.key);
+      if (relation == null) continue;
+      final v = value as Map<String, dynamic>;
+
+      if (relation.type == RelationType.manyToMany) {
+        if (v.containsKey('connect')) {
+          mutations.addAll(_compileConnectOperations(
+            parentId: parentId.toString(),
+            relation: relation,
+            connectItems: _normalizeConnectDisconnect(v['connect']),
+            effectiveSchema: effectiveSchema,
+          ));
+        }
+        if (v.containsKey('disconnect')) {
+          mutations.addAll(_compileDisconnectOperations(
+            parentId: parentId.toString(),
+            relation: relation,
+            disconnectItems: _normalizeConnectDisconnect(v['disconnect']),
+            effectiveSchema: effectiveSchema,
+          ));
+        }
+      } else if (relation.type == RelationType.oneToMany ||
+          relation.type == RelationType.oneToOne) {
+        // Nested create: child rows carry the FK back to the parent.
+        if (v.containsKey('create')) {
+          final creates = v['create'];
+          final createList = creates is List
+              ? List<Map<String, dynamic>>.from(creates)
+              : [creates as Map<String, dynamic>];
+          final targetModel = effectiveSchema.getModel(relation.targetModel);
+          for (final createData in createList) {
+            final childData = Map<String, dynamic>.from(createData);
+            childData[relation.foreignKey] = parentId;
+            if (targetModel != null) {
+              for (final field in targetModel.fields.values) {
+                if (childData.containsKey(field.name)) continue;
+                if (field.defaultValue == 'uuid()' ||
+                    field.defaultValue == 'cuid()') {
+                  if (provider == 'postgresql' || provider == 'supabase') {
+                    childData[field.name] = const _RawSql('gen_random_uuid()');
+                  }
+                } else if (field.defaultValue == 'now()' || field.isUpdatedAt) {
+                  childData[field.name] =
+                      (provider == 'postgresql' || provider == 'supabase')
+                          ? const _RawSql('NOW()')
+                          : DateTime.now().toUtc().toIso8601String();
+                }
+              }
+            }
+            mutations.add(compile(JsonQuery(
+              modelName: targetModel?.tableName ?? relation.targetModel,
+              action: 'create',
+              args: JsonQueryArgs(arguments: {'data': childData}),
+            )));
+          }
+        }
+      }
+    }
+    return mutations;
   }
 
   /// Normalize connect/disconnect input to a list of maps.

--- a/lib/src/runtime/schema/schema_registry.dart
+++ b/lib/src/runtime/schema/schema_registry.dart
@@ -36,50 +36,60 @@ final schemaRegistry = SchemaRegistry();
 class SchemaRegistry {
   final Map<String, ModelSchema> _models = {};
 
-  /// Register a model schema.
+  /// Secondary index by database table name (`@@map`). Generated delegates
+  /// address queries by table name, so lookups must resolve either the Prisma
+  /// model name (`Author`) or the mapped table name (`authors`).
+  final Map<String, ModelSchema> _modelsByTable = {};
+
+  /// Register a model schema (indexed by both model name and table name).
   void registerModel(ModelSchema schema) {
     _models[schema.name] = schema;
+    _modelsByTable[schema.tableName] = schema;
   }
 
-  /// Get a model schema by name.
-  ModelSchema? getModel(String name) => _models[name];
+  /// Get a model schema by Prisma model name or mapped table name.
+  ModelSchema? getModel(String name) => _models[name] ?? _modelsByTable[name];
 
   /// Get relation info for a model's field.
   RelationInfo? getRelation(String modelName, String fieldName) {
-    return _models[modelName]?.relations[fieldName];
+    return getModel(modelName)?.relations[fieldName];
   }
 
   /// Get all relations for a model.
   Map<String, RelationInfo> getRelations(String modelName) {
-    return _models[modelName]?.relations ?? {};
+    return getModel(modelName)?.relations ?? {};
   }
 
   /// Get field info for a model's field.
   FieldInfo? getField(String modelName, String fieldName) {
-    return _models[modelName]?.fields[fieldName];
+    return getModel(modelName)?.fields[fieldName];
   }
 
   /// Get the primary key field(s) for a model.
   List<FieldInfo> getPrimaryKeys(String modelName) {
-    final model = _models[modelName];
+    final model = getModel(modelName);
     if (model == null) return [];
 
     return model.fields.values.where((f) => f.isId).toList();
   }
 
-  /// Get table name for a model.
+  /// Get table name for a model (accepts model name or table name).
   String? getTableName(String modelName) {
-    return _models[modelName]?.tableName;
+    return getModel(modelName)?.tableName;
   }
 
-  /// Check if a model exists.
-  bool hasModel(String name) => _models.containsKey(name);
+  /// Check if a model exists (by model name or mapped table name).
+  bool hasModel(String name) =>
+      _models.containsKey(name) || _modelsByTable.containsKey(name);
 
   /// Get all registered model names.
   List<String> get modelNames => _models.keys.toList();
 
   /// Clear all registered models (useful for testing).
-  void clear() => _models.clear();
+  void clear() {
+    _models.clear();
+    _modelsByTable.clear();
+  }
 }
 
 /// Schema definition for a Prisma model.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,10 @@ dependencies:
   json_annotation: ^4.9.0
   mysql1: ^0.20.0
   postgres: ^3.0.0
+  # Wide range so consumers on sentry 8.x (e.g. the mobile backend) and 9.x
+  # (the Flutter app) both resolve; the connector only uses the stable
+  # captureException / isEnabled surface.
+  sentry: ">=8.0.0 <10.0.0"
   sqflite: ^2.3.0
   supabase_flutter: ^2.5.0
   web_socket_channel: ">=2.4.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues

--- a/test/unit/delegate_generator_composite_id_test.dart
+++ b/test/unit/delegate_generator_composite_id_test.dart
@@ -10,7 +10,7 @@ void main() {
       parser = PrismaParser();
     });
 
-    test('omits unique-keyed methods when model has no unique scalar field',
+    test('composite @@id models get unique-keyed methods via the compound key',
         () {
       const schema = '''
 model OrgInvoiceCounter {
@@ -26,17 +26,33 @@ model OrgInvoiceCounter {
       final parsed = parser.parse(schema);
       final generator = CbDelegateGenerator(parsed, serverMode: true);
 
-      // Must not throw (previously emitted invalid Dart for these models)
+      // Must not throw, and now DOES get unique-keyed methods keyed by the
+      // compound @@id (C6). WhereUniqueInput exists and carries the compound.
       final code = generator.generateDelegate(parsed.models.first);
 
-      expect(code, isNot(contains('findUnique')));
-      expect(code, isNot(contains('WhereUniqueInput')));
+      expect(code, contains('findUnique'));
+      expect(code, contains('OrgInvoiceCounterWhereUniqueInput'));
       expect(code, contains('findMany'));
-      expect(code, contains('findFirst'));
       expect(code, contains('updateMany'));
       expect(code, contains('deleteMany'));
       // @@map flows into the generated table name
       expect(code, contains('org_invoice_counters'));
+    });
+
+    test('model with no field-level or composite unique omits unique methods',
+        () {
+      const schema = '''
+model AuditLine {
+  message String
+  at      DateTime @default(now())
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+      expect(code, isNot(contains('findUnique')));
+      expect(code, isNot(contains('WhereUniqueInput')));
+      expect(code, contains('findMany'));
     });
 
     test('keeps unique-keyed methods for models with @id field', () {
@@ -89,7 +105,7 @@ model User {
       expect(code, contains('Future<User> findFirstOrThrow('));
     });
 
-    test('upsert is omitted for composite-@@id-only models', () {
+    test('upsert IS generated for composite-@@id models', () {
       const schema = '''
 model OrgInvoiceCounter {
   organizationId String
@@ -103,7 +119,7 @@ model OrgInvoiceCounter {
       final code = CbDelegateGenerator(parsed, serverMode: true)
           .generateDelegate(parsed.models.first);
 
-      expect(code, isNot(contains('upsert(')));
+      expect(code, contains('upsert('));
     });
   });
 }

--- a/test/unit/delegate_generator_composite_id_test.dart
+++ b/test/unit/delegate_generator_composite_id_test.dart
@@ -89,6 +89,23 @@ model User {
       expect(code, contains('QueryAction.upsert'));
     });
 
+    test('findMany/findFirst take a typed XInclude param', () {
+      const schema = '''
+model Post {
+  id       String @id
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId String
+}
+model User { id String @id }
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+      expect(code, contains('PostInclude? include'));
+      expect(code, isNot(contains("include: refer('Map<String, dynamic>?')")));
+      expect(code, contains('include.toJson()'));
+    });
+
     test('aggregate + findFirstOrThrow are generated', () {
       const schema = '''
 model User {

--- a/test/unit/delegate_generator_composite_id_test.dart
+++ b/test/unit/delegate_generator_composite_id_test.dart
@@ -73,6 +73,22 @@ model User {
       expect(code, contains('QueryAction.upsert'));
     });
 
+    test('aggregate + findFirstOrThrow are generated', () {
+      const schema = '''
+model User {
+  id     String @id @default(cuid())
+  rating Int
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+
+      expect(code, contains('Future<Map<String, dynamic>> aggregate('));
+      expect(code, contains('QueryAction.aggregate'));
+      expect(code, contains('Future<User> findFirstOrThrow('));
+    });
+
     test('upsert is omitted for composite-@@id-only models', () {
       const schema = '''
 model OrgInvoiceCounter {

--- a/test/unit/delegate_generator_composite_id_test.dart
+++ b/test/unit/delegate_generator_composite_id_test.dart
@@ -106,6 +106,33 @@ model User { id String @id }
       expect(code, contains('include.toJson()'));
     });
 
+    test('findMany takes a typed cursor param wired to the query builder', () {
+      const schema = '''
+model Post {
+  id       String @id
+  authorId String
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+      expect(code, contains('PostWhereUniqueInput? cursor'));
+      expect(code, contains('queryBuilder.cursor(_whereUniqueToJson(cursor))'));
+    });
+
+    test('unique-less model omits the cursor param', () {
+      const schema = '''
+model AuditLine {
+  message String
+  at      DateTime @default(now())
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+      expect(code, isNot(contains('cursor')));
+    });
+
     test('aggregate + findFirstOrThrow are generated', () {
       const schema = '''
 model User {

--- a/test/unit/delegate_generator_composite_id_test.dart
+++ b/test/unit/delegate_generator_composite_id_test.dart
@@ -55,5 +55,39 @@ model User {
       expect(code, contains('findUnique'));
       expect(code, contains('UserWhereUniqueInput'));
     });
+
+    test('upsert is generated for models with a unique field', () {
+      const schema = '''
+model User {
+  id    String @id @default(cuid())
+  email String @unique
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+
+      expect(code, contains('Future<User> upsert('));
+      expect(code, contains('CreateUserInput create'));
+      expect(code, contains('UpdateUserInput update'));
+      expect(code, contains('QueryAction.upsert'));
+    });
+
+    test('upsert is omitted for composite-@@id-only models', () {
+      const schema = '''
+model OrgInvoiceCounter {
+  organizationId String
+  fiscalYear     String
+  lastNumber     Int    @default(0)
+
+  @@id([organizationId, fiscalYear])
+}
+''';
+      final parsed = parser.parse(schema);
+      final code = CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+
+      expect(code, isNot(contains('upsert(')));
+    });
   });
 }

--- a/test/unit/delegate_generator_nested_write_test.dart
+++ b/test/unit/delegate_generator_nested_write_test.dart
@@ -39,8 +39,7 @@ void main() {
     test('create routes to relations engine when relation ops present', () {
       final flat = _flat(delegateCode('Post'));
       expect(flat, contains("const relationFields = {'author', 'comments'}"));
-      expect(
-          flat, contains('data0.keys.any(relationFields.contains)'));
+      expect(flat, contains('data0.keys.any(relationFields.contains)'));
       expect(flat,
           contains('_executor.executeMutationWithRelationsReturning(query)'));
     });

--- a/test/unit/delegate_generator_nested_write_test.dart
+++ b/test/unit/delegate_generator_nested_write_test.dart
@@ -1,0 +1,66 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_delegate_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+const _schema = '''
+model Post {
+  id       String    @id @default(cuid())
+  title    String
+  author   User      @relation(fields: [authorId], references: [id])
+  authorId String
+  comments Comment[]
+}
+
+model User {
+  id    String @id
+  name  String
+  posts Post[]
+}
+
+model Comment {
+  id     String @id
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
+}
+''';
+
+void main() {
+  group('CbDelegateGenerator nested-write routing (#64)', () {
+    late PrismaSchema parsed;
+
+    setUp(() => parsed = PrismaParser().parse(_schema));
+
+    String delegateCode(String name) =>
+        CbDelegateGenerator(parsed, serverMode: true)
+            .generateDelegate(parsed.models.firstWhere((m) => m.name == name));
+
+    test('create routes to relations engine when relation ops present', () {
+      final flat = _flat(delegateCode('Post'));
+      expect(flat, contains("const relationFields = {'author', 'comments'}"));
+      expect(
+          flat, contains('data0.keys.any(relationFields.contains)'));
+      expect(flat,
+          contains('_executor.executeMutationWithRelationsReturning(query)'));
+    });
+
+    test('update routes to relations engine when relation ops present', () {
+      final flat = _flat(delegateCode('Post'));
+      // update falls back to plain executeMutation otherwise
+      expect(flat, contains('_executor.executeMutation(query)'));
+      expect(flat,
+          contains('_executor.executeMutationWithRelationsReturning(query)'));
+    });
+
+    test('relation-less model uses an empty relation-field set', () {
+      const schema = '''
+model Tag { id String @id name String }
+''';
+      final p = PrismaParser().parse(schema);
+      final flat = _flat(CbDelegateGenerator(p, serverMode: true)
+          .generateDelegate(p.models.first));
+      expect(flat, contains('const relationFields = const <String>{}'));
+    });
+  });
+}

--- a/test/unit/filter_types_json_test.dart
+++ b/test/unit/filter_types_json_test.dart
@@ -29,5 +29,28 @@ model Event {
           .generateModel(p.models.firstWhere((m) => m.name == 'Event')));
       expect(flat, contains('JsonFilter? meta'));
     });
+
+    test('filter types include BigIntFilter + BytesFilter', () {
+      final flat = _flat(CbFilterTypesGenerator(parsed).generate());
+      expect(flat, contains('class BigIntFilter'));
+      expect(flat, contains('class BytesFilter'));
+      // BigInt values serialize via toString() in toJson
+      expect(flat, contains('equals!.toString()'));
+    });
+
+    test('BigInt/Bytes columns map to their filters in WhereInput', () {
+      const schema = '''
+model Blob {
+  id    String @id
+  size  BigInt
+  data  Bytes
+}
+''';
+      final p = PrismaParser().parse(schema);
+      final flat = _flat(CbModelGenerator(p)
+          .generateModel(p.models.firstWhere((m) => m.name == 'Blob')));
+      expect(flat, contains('BigIntFilter? size'));
+      expect(flat, contains('BytesFilter? data'));
+    });
   });
 }

--- a/test/unit/filter_types_json_test.dart
+++ b/test/unit/filter_types_json_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_filter_types_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_model_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+void main() {
+  group('JsonFilter generation (#69)', () {
+    final parsed = PrismaParser().parse('model Ping { id String @id }');
+
+    test('filter types include a JsonFilter with path + operators', () {
+      final flat = _flat(CbFilterTypesGenerator(parsed).generate());
+      expect(flat, contains('class JsonFilter'));
+      expect(flat, contains("JsonKey(name: 'string_contains')"));
+      expect(flat, contains("JsonKey(name: 'array_contains')"));
+      expect(flat, contains('List<String>? path'));
+    });
+
+    test('Json columns map to JsonFilter in WhereInput', () {
+      const schema = '''
+model Event {
+  id   String @id
+  meta Json
+}
+''';
+      final p = PrismaParser().parse(schema);
+      final flat = _flat(CbModelGenerator(p)
+          .generateModel(p.models.firstWhere((m) => m.name == 'Event')));
+      expect(flat, contains('JsonFilter? meta'));
+    });
+  });
+}

--- a/test/unit/model_generator_composite_unique_test.dart
+++ b/test/unit/model_generator_composite_unique_test.dart
@@ -1,0 +1,82 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_model_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+
+/// Collapse whitespace so assertions ignore dart_style line-wrapping.
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+void main() {
+  group('CbModelGenerator composite unique keys (#C6)', () {
+    test('@@id([a,b]) generates a compound-unique input + flatten toJson', () {
+      const schema = '''
+model OrgInvoiceCounter {
+  organizationId String
+  fiscalYear     String
+  lastNumber     Int    @default(0)
+
+  @@id([organizationId, fiscalYear])
+}
+''';
+      final parsed = PrismaParser().parse(schema);
+      final code = CbModelGenerator(parsed).generateModel(parsed.models.first);
+      final flat = _flat(code);
+
+      // Compound input class with both typed fields
+      expect(
+          flat,
+          contains(
+              'class OrgInvoiceCounterOrganizationIdFiscalYearCompoundUnique'));
+      expect(flat, contains('required String organizationId'));
+      expect(flat, contains('required String fiscalYear'));
+
+      // WhereUniqueInput carries the compound field named a_b
+      expect(flat, contains('OrgInvoiceCounterWhereUniqueInput'));
+      expect(
+          flat,
+          contains(
+              'OrgInvoiceCounterOrganizationIdFiscalYearCompoundUnique? organizationId_fiscalYear'));
+
+      // WhereUniqueInput.toJson FLATTENS the compound via spread
+      expect(flat, contains('...organizationId_fiscalYear!.toJson()'));
+      // The compound toJson emits the individual field keys
+      expect(flat, contains("'organizationId': organizationId"));
+      expect(flat, contains("'fiscalYear': fiscalYear"));
+    });
+
+    test('@@unique([a,b]) on a model with an @id also gets a compound input',
+        () {
+      const schema = '''
+model Membership {
+  id     String @id @default(cuid())
+  userId String
+  orgId  String
+
+  @@unique([userId, orgId])
+}
+''';
+      final parsed = PrismaParser().parse(schema);
+      final code = CbModelGenerator(parsed).generateModel(parsed.models.first);
+      final flat = _flat(code);
+
+      // Both the id field and the compound are addressable
+      expect(flat, contains('String? id'));
+      expect(
+          flat, contains('MembershipUserIdOrgIdCompoundUnique? userId_orgId'));
+      expect(flat, contains('...userId_orgId!.toJson()'));
+    });
+
+    test('single-field @@unique([x]) does NOT create a compound input', () {
+      const schema = '''
+model Slug {
+  id   String @id
+  name String
+
+  @@unique([name])
+}
+''';
+      final parsed = PrismaParser().parse(schema);
+      // parser only records composites with >1 field
+      expect(parsed.models.first.compositeUniques, isEmpty);
+    });
+  });
+}

--- a/test/unit/model_generator_include_test.dart
+++ b/test/unit/model_generator_include_test.dart
@@ -1,0 +1,79 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_model_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+const _schema = '''
+model Post {
+  id       String    @id @default(cuid())
+  title    String
+  author   User      @relation(fields: [authorId], references: [id])
+  authorId String
+  comments Comment[]
+}
+
+model User {
+  id    String @id
+  name  String
+  posts Post[]
+}
+
+model Comment {
+  id     String @id
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
+}
+''';
+
+void main() {
+  group('CbModelGenerator relation hydration (#67)', () {
+    late PrismaSchema parsed;
+
+    setUp(() => parsed = PrismaParser().parse(_schema));
+
+    String modelCode(String name) => CbModelGenerator(parsed)
+        .generateModel(parsed.models.firstWhere((m) => m.name == name));
+
+    test('fromJson hydrates a to-one relation into the typed model', () {
+      final flat = _flat(modelCode('Post'));
+      expect(
+        flat,
+        contains("author: json['author'] != null ? "
+            "User.fromJson(json['author'] as Map<String, dynamic>) : null"),
+      );
+    });
+
+    test('fromJson hydrates a to-many relation into a typed list', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains("json['comments'] as List?"));
+      expect(flat, contains('Comment.fromJson(e as Map<String, dynamic>)'));
+      expect(flat, contains('.toList() ?? const []'));
+    });
+
+    test('scalar fields still deserialize normally', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains("title: json['title'] as String"));
+    });
+
+    test('typed XInclude class carries a field per relation', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains('class PostInclude'));
+      expect(flat, contains('UserInclude? author'));
+      expect(flat, contains('CommentInclude? comments'));
+      // toJson nests empty-include -> true, else {'include': ...}
+      expect(flat, contains('final n = author!.toJson();'));
+      expect(
+          flat,
+          contains(
+              "map['author'] = n.isEmpty ? true : <String, dynamic>{'include': n}"));
+    });
+
+    test('relation-less model gets an empty XInclude', () {
+      final flat = _flat(modelCode('User'));
+      // User has a relation (posts) so isn't empty; assert its Include exists
+      expect(flat, contains('class UserInclude'));
+      expect(flat, contains('PostInclude? posts'));
+    });
+  });
+}

--- a/test/unit/model_generator_nested_write_test.dart
+++ b/test/unit/model_generator_nested_write_test.dart
@@ -1,0 +1,77 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_model_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+const _schema = '''
+model Post {
+  id       String    @id @default(cuid())
+  title    String
+  author   User      @relation(fields: [authorId], references: [id])
+  authorId String
+  comments Comment[]
+}
+
+model User {
+  id    String @id
+  name  String
+  posts Post[]
+}
+
+model Comment {
+  id     String @id
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
+}
+''';
+
+void main() {
+  group('CbModelGenerator nested relation writes (#64)', () {
+    late PrismaSchema parsed;
+
+    setUp(() => parsed = PrismaParser().parse(_schema));
+
+    String modelCode(String name) => CbModelGenerator(parsed)
+        .generateModel(parsed.models.firstWhere((m) => m.name == name));
+
+    test('per-relation write input classes are generated', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains('class PostAuthorWriteInput'));
+      expect(flat, contains('class PostCommentsWriteInput'));
+    });
+
+    test('to-one write input has connect + create', () {
+      final flat = _flat(modelCode('Post'));
+      // author -> User (has @id) so connect is available
+      expect(flat, contains('UserWhereUniqueInput? connect'));
+      expect(flat, contains('CreateUserInput? create'));
+    });
+
+    test('to-many write input has list connect/disconnect + create', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains('List<CommentWhereUniqueInput>? connect'));
+      expect(flat, contains('List<CommentWhereUniqueInput>? disconnect'));
+      expect(flat, contains('List<CreateCommentInput>? create'));
+    });
+
+    test('CreateInput carries an optional param per relation', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains('PostAuthorWriteInput? author'));
+      expect(flat, contains('PostCommentsWriteInput? comments'));
+    });
+
+    test('UpdateInput carries an optional param per relation', () {
+      // User has a to-many relation (posts)
+      final flat = _flat(modelCode('User'));
+      expect(flat, contains('UserPostsWriteInput? posts'));
+    });
+
+    test('CreateInput.toJson emits relation writes when present', () {
+      final flat = _flat(modelCode('Post'));
+      expect(flat, contains("if (author != null) 'author': author!.toJson()"));
+      expect(flat,
+          contains("if (comments != null) 'comments': comments!.toJson()"));
+    });
+  });
+}

--- a/test/unit/postgres_pooled_adapter_test.dart
+++ b/test/unit/postgres_pooled_adapter_test.dart
@@ -1,0 +1,36 @@
+import 'package:test/test.dart';
+import 'package:postgres/postgres.dart' as pg;
+import 'package:prisma_flutter_connector/src/runtime/adapters/postgres_adapter.dart';
+
+/// Unit-level checks for the pooled adapter (#70). Live pool behaviour
+/// (borrow/pin/return per transaction) is covered by the integration suite;
+/// here we only assert construction + mode flags without opening sockets.
+void main() {
+  group('PostgresAdapter.pooled (#70)', () {
+    late pg.Pool pool;
+
+    setUp(() {
+      // withEndpoints is lazy — no connection is opened until a query runs.
+      pool = pg.Pool.withEndpoints([
+        pg.Endpoint(host: 'localhost', database: 'db', username: 'u'),
+      ]);
+    });
+
+    tearDown(() async {
+      await pool.close(force: true);
+    });
+
+    test('reports pooled mode and postgres provider', () {
+      final adapter = PostgresAdapter.pooled(pool);
+      expect(adapter.isPooled, isTrue);
+      expect(adapter.provider, 'postgresql');
+    });
+
+    test('exposes the default connection info', () {
+      final adapter = PostgresAdapter.pooled(pool);
+      final info = adapter.getConnectionInfo();
+      expect(info, isNotNull);
+      expect(info!.supportsRelationJoins, isTrue);
+    });
+  });
+}

--- a/test/unit/query_executor_test.dart
+++ b/test/unit/query_executor_test.dart
@@ -323,7 +323,10 @@ void main() {
         expect(result, isEmpty);
       });
 
-      test('converts snake_case columns to camelCase', () async {
+      test('preserves raw DB column names as keys', () async {
+        // Generated models deserialize by DB column name (@map), so the
+        // executor must NOT camelCase columns — that would desync @map-ed
+        // columns like `author_id` from what fromJson reads.
         final query = JsonQueryBuilder()
             .model('User')
             .action(QueryAction.findMany)
@@ -343,10 +346,10 @@ void main() {
 
         final result = await executor.executeQueryAsMaps(query);
 
-        expect(result[0].containsKey('userId'), true);
-        expect(result[0].containsKey('firstName'), true);
-        expect(result[0].containsKey('createdAt'), true);
-        expect(result[0].containsKey('user_id'), false);
+        expect(result[0].containsKey('user_id'), true);
+        expect(result[0].containsKey('first_name'), true);
+        expect(result[0].containsKey('created_at'), true);
+        expect(result[0].containsKey('userId'), false);
       });
 
       test('deserializes DateTime values', () async {
@@ -365,8 +368,8 @@ void main() {
 
         final result = await executor.executeQueryAsMaps(query);
 
-        expect(result[0]['createdAt'], isA<DateTime>());
-        final date = result[0]['createdAt'] as DateTime;
+        expect(result[0]['created_at'], isA<DateTime>());
+        final date = result[0]['created_at'] as DateTime;
         expect(date.year, 2024);
         expect(date.month, 1);
         expect(date.day, 15);
@@ -389,7 +392,7 @@ void main() {
 
         final result = await executor.executeQueryAsMaps(query);
 
-        expect(result[0]['createdAt'], testDate);
+        expect(result[0]['created_at'], testDate);
       });
 
       test('deserializes date values', () async {
@@ -408,7 +411,7 @@ void main() {
 
         final result = await executor.executeQueryAsMaps(query);
 
-        expect(result[0]['birthDate'], isA<DateTime>());
+        expect(result[0]['birth_date'], isA<DateTime>());
       });
 
       test('converts SQLite boolean (int to bool)', () async {
@@ -428,8 +431,8 @@ void main() {
 
         final result = await executor.executeQueryAsMaps(query);
 
-        expect(result[0]['isActive'], true);
-        expect(result[1]['isActive'], false);
+        expect(result[0]['is_active'], true);
+        expect(result[1]['is_active'], false);
       });
 
       test('handles null values', () async {
@@ -776,7 +779,7 @@ void main() {
         expect(result, isNull);
       });
 
-      test('converts snake_case to camelCase in transaction', () async {
+      test('preserves raw column names in transaction', () async {
         final txMock = MockTransaction();
         txMock.nextQueryResult = const SqlResultSet(
           columnNames: ['user_id', 'created_at'],
@@ -798,8 +801,8 @@ void main() {
           return null;
         });
 
-        expect(result![0].containsKey('userId'), true);
-        expect(result![0].containsKey('createdAt'), true);
+        expect(result![0].containsKey('user_id'), true);
+        expect(result![0].containsKey('created_at'), true);
       });
     });
 
@@ -886,7 +889,7 @@ void main() {
 
       final result = await executor.executeQueryAsMaps(query);
 
-      expect(result[0].containsKey('userProfilePictureUrl'), true);
+      expect(result[0].containsKey('user_profile_picture_url'), true);
     });
 
     test('handles already camelCase columns', () async {

--- a/test/unit/query_executor_test.dart
+++ b/test/unit/query_executor_test.dart
@@ -11,6 +11,7 @@ class MockAdapter implements SqlDriverAdapter {
   int nextExecuteResult = 0;
   Exception? shouldThrow;
   MockTransaction? mockTransaction;
+  int startTransactionCount = 0;
 
   @override
   String get provider => 'postgresql';
@@ -66,6 +67,7 @@ class MockAdapter implements SqlDriverAdapter {
 
   @override
   Future<Transaction> startTransaction([IsolationLevel? isolationLevel]) async {
+    startTransactionCount++;
     // Return pre-configured mock if set, otherwise create new one
     mockTransaction ??= MockTransaction();
     return mockTransaction!;
@@ -647,6 +649,50 @@ void main() {
         });
 
         expect(mockAdapter.mockTransaction!.executedQueries.length, 2);
+        expect(mockAdapter.mockTransaction!.committed, true);
+      });
+    });
+
+    group('runTransaction (#68)', () {
+      test('QueryExecutor.runTransaction opens a transaction and commits',
+          () async {
+        final result = await executor.runTransaction((tx) async {
+          expect(tx, isA<TransactionExecutor>());
+          return 'ok';
+        });
+
+        expect(result, 'ok');
+        expect(mockAdapter.startTransactionCount, 1);
+        expect(mockAdapter.mockTransaction!.committed, true);
+      });
+
+      test('nested runTransaction flattens onto the ambient transaction',
+          () async {
+        late BaseExecutor outerTx;
+        late BaseExecutor innerTx;
+
+        await executor.runTransaction((tx) async {
+          outerTx = tx;
+          return tx.runTransaction((inner) async {
+            innerTx = inner;
+            return null;
+          });
+        });
+
+        // Only one BEGIN, and the nested call reused the same executor.
+        expect(mockAdapter.startTransactionCount, 1);
+        expect(identical(innerTx, outerTx), true);
+        expect(mockAdapter.mockTransaction!.committed, true);
+      });
+
+      test('TransactionExecutor.dispose is a no-op (does not break the tx)',
+          () async {
+        final result = await executor.runTransaction((tx) async {
+          await tx.dispose(); // must not close the shared connection
+          return 'still-usable';
+        });
+
+        expect(result, 'still-usable');
         expect(mockAdapter.mockTransaction!.committed, true);
       });
     });

--- a/test/unit/sentry_query_logger_test.dart
+++ b/test/unit/sentry_query_logger_test.dart
@@ -1,0 +1,36 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/runtime/logging/sentry_query_logger.dart';
+import 'package:prisma_flutter_connector/src/runtime/logging/query_logger.dart';
+
+void main() {
+  group('SentryQueryLogger', () {
+    test('is a no-op when Sentry is not enabled (safe to always include)', () {
+      const logger = SentryQueryLogger();
+      // Sentry.isEnabled is false in tests → these must not throw.
+      expect(
+        () => logger.onQueryError(QueryErrorEvent(
+          sql: 'SELECT 1',
+          parameters: const [],
+          operation: 'findMany',
+          model: 'User',
+          duration: const Duration(milliseconds: 3),
+          error: Exception('boom'),
+        )),
+        returnsNormally,
+      );
+      expect(
+        () => logger.onQueryStart(QueryStartEvent(
+            sql: 'x', parameters: const [], startTime: DateTime(2020))),
+        returnsNormally,
+      );
+    });
+
+    test('composes with other loggers via CompositeQueryLogger', () {
+      final composite = CompositeQueryLogger(const [
+        ConsoleQueryLogger(includeSql: false),
+        SentryQueryLogger(),
+      ]);
+      expect(composite, isA<QueryLogger>());
+    });
+  });
+}

--- a/test/unit/sql_compiler_c10_gaps_test.dart
+++ b/test/unit/sql_compiler_c10_gaps_test.dart
@@ -1,0 +1,126 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/runtime/query/sql_compiler.dart';
+import 'package:prisma_flutter_connector/src/runtime/query/json_protocol.dart';
+import 'package:prisma_flutter_connector/src/runtime/query/relation_compiler.dart';
+import 'package:prisma_flutter_connector/src/runtime/adapters/types.dart';
+import 'package:prisma_flutter_connector/src/runtime/schema/schema_registry.dart';
+
+void main() {
+  group('Atomic update ops (#70 gaps)', () {
+    final compiler = SqlCompiler(provider: 'postgresql');
+
+    SqlQuery update(Map<String, dynamic> data) => compiler.compile(
+          JsonQueryBuilder()
+              .model('Counter')
+              .action(QueryAction.update)
+              .where({'id': 'c1'})
+              .data(data)
+              .build(),
+        );
+
+    test('increment -> col = col + ?', () {
+      final r = update({
+        'count': {'increment': 5}
+      });
+      expect(r.sql, contains('"count" = "count" + \$1'));
+      expect(r.args.first, 5);
+    });
+
+    test('decrement/multiply/divide map to -, *, /', () {
+      expect(
+          update({
+            'count': {'decrement': 1}
+          }).sql,
+          contains('"count" = "count" - \$1'));
+      expect(
+          update({
+            'count': {'multiply': 2}
+          }).sql,
+          contains('"count" = "count" * \$1'));
+      expect(
+          update({
+            'count': {'divide': 2}
+          }).sql,
+          contains('"count" = "count" / \$1'));
+    });
+
+    test('set -> plain assignment', () {
+      final r = update({
+        'count': {'set': 0}
+      });
+      expect(r.sql, contains('"count" = \$1'));
+      expect(r.sql, isNot(contains('"count" = "count"')));
+    });
+
+    test('plain scalar still assigns directly', () {
+      final r = update({'name': 'x'});
+      expect(r.sql, contains('"name" = \$1'));
+    });
+  });
+
+  group('createManyAndReturn + skipDuplicates (#70 gaps)', () {
+    final compiler = SqlCompiler(provider: 'postgresql');
+
+    test('skipDuplicates -> ON CONFLICT DO NOTHING', () {
+      final r = compiler.compile(JsonQueryBuilder()
+          .model('Tag')
+          .action(QueryAction.createMany)
+          .data({
+            'data': [
+              {'id': 'a'}
+            ]
+          })
+          .skipDuplicates()
+          .build());
+      expect(r.sql, contains('ON CONFLICT DO NOTHING'));
+      expect(r.sql, isNot(contains('RETURNING')));
+    });
+
+    test('createManyAndReturn -> RETURNING *', () {
+      final r = compiler.compile(JsonQueryBuilder()
+          .model('Tag')
+          .action(QueryAction.createManyAndReturn)
+          .data({
+        'data': [
+          {'id': 'a'}
+        ]
+      }).build());
+      expect(r.sql, contains('RETURNING *'));
+    });
+  });
+
+  group('Nested include depth guard (#70 gaps)', () {
+    test('exceeding maxIncludeDepth throws', () {
+      final schema = SchemaRegistry();
+      // Self-referential model: Node -> child Node -> ...
+      schema.registerModel(ModelSchema(
+        name: 'Node',
+        tableName: 'Node',
+        fields: {
+          'id': const FieldInfo(
+              name: 'id', columnName: 'id', type: 'String', isId: true),
+          'parentId': const FieldInfo(
+              name: 'parentId', columnName: 'parentId', type: 'String'),
+        },
+        relations: {
+          'child': RelationInfo.manyToOne(
+              name: 'child', targetModel: 'Node', foreignKey: 'parentId'),
+        },
+      ));
+      final rc = RelationCompiler(schema: schema);
+
+      // Build an include nested deeper than the limit.
+      Map<String, dynamic> nest(int n) =>
+          n == 0 ? {'child': true} : {'child': {'include': nest(n - 1)}};
+
+      expect(
+        () => rc.compile(
+          baseModel: 'Node',
+          baseAlias: 't0',
+          include: nest(RelationCompiler.maxIncludeDepth + 1),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/test/unit/sql_compiler_c10_gaps_test.dart
+++ b/test/unit/sql_compiler_c10_gaps_test.dart
@@ -110,8 +110,11 @@ void main() {
       final rc = RelationCompiler(schema: schema);
 
       // Build an include nested deeper than the limit.
-      Map<String, dynamic> nest(int n) =>
-          n == 0 ? {'child': true} : {'child': {'include': nest(n - 1)}};
+      Map<String, dynamic> nest(int n) => n == 0
+          ? {'child': true}
+          : {
+              'child': {'include': nest(n - 1)}
+            };
 
       expect(
         () => rc.compile(

--- a/test/unit/sql_compiler_map_test.dart
+++ b/test/unit/sql_compiler_map_test.dart
@@ -181,6 +181,20 @@ void main() {
       expect(r.sql, contains('COUNT(*)'));
     });
 
+    test('aggregate resolves @map field in function arg, aliases by field', () {
+      final q = JsonQueryBuilder()
+          .model('User')
+          .action(QueryAction.aggregate)
+          .aggregation({
+        '_count': true,
+        '_min': {'status': true},
+      }).build();
+      final r = compiler.compile(q);
+      // MIN over the DB column, alias keeps the Dart field name
+      expect(r.sql, contains('MIN("requestStatus") AS "_min_status"'));
+      expect(r.sql, contains('COUNT(*)'));
+    });
+
     test('upsert resolves @map conflict + column names', () {
       final q = JsonQueryBuilder()
           .model('User')

--- a/test/unit/sql_compiler_map_test.dart
+++ b/test/unit/sql_compiler_map_test.dart
@@ -168,6 +168,33 @@ void main() {
           .build());
       expect(ok.sql, 'SELECT * FROM "users"');
     });
+
+    test('groupBy resolves @map field to column and aliases back', () {
+      final q = JsonQueryBuilder()
+          .model('User')
+          .action(QueryAction.groupBy)
+          .groupByFields(['status']).aggregation({'_count': true}).build();
+      final r = compiler.compile(q);
+      // Dart field 'status' -> column "requestStatus"; SELECT aliases it back
+      expect(r.sql, contains('"requestStatus" AS "status"'));
+      expect(r.sql, contains('GROUP BY "requestStatus"'));
+      expect(r.sql, contains('COUNT(*)'));
+    });
+
+    test('upsert resolves @map conflict + column names', () {
+      final q = JsonQueryBuilder()
+          .model('User')
+          .action(QueryAction.upsert)
+          .where({'id': 'u1'}).data({
+        'create': {'id': 'u1', 'status': 'PENDING'},
+        'update': {'status': 'APPROVED'},
+      }).build();
+      final r = compiler.compile(q);
+      expect(r.sql, contains('INSERT INTO "users"'));
+      expect(r.sql, contains('"requestStatus"'));
+      expect(r.sql, contains('ON CONFLICT ("id")'));
+      expect(r.sql, isNot(contains('"status"')));
+    });
   });
 
   group('SqlCompiler with @@map-ed registry (sqlite)', () {

--- a/test/unit/sql_compiler_test.dart
+++ b/test/unit/sql_compiler_test.dart
@@ -3827,5 +3827,103 @@ void main() {
         expect(() => cc.compile(q), throwsArgumentError);
       });
     });
+
+    group('Nested writes (#64)', () {
+      late SchemaRegistry nestedSchema;
+      late SqlCompiler compiler;
+
+      setUp(() {
+        nestedSchema = SchemaRegistry();
+        nestedSchema.registerModel(ModelSchema(
+          name: 'Product',
+          tableName: 'Product',
+          fields: {
+            'id': const FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+            'authorId': const FieldInfo(
+                name: 'authorId', columnName: 'authorId', type: 'String'),
+          },
+          relations: {
+            'reviews': RelationInfo.oneToMany(
+                name: 'reviews', targetModel: 'Review', foreignKey: 'productId'),
+            'author': RelationInfo.manyToOne(
+                name: 'author', targetModel: 'User', foreignKey: 'authorId'),
+          },
+        ));
+        nestedSchema.registerModel(const ModelSchema(
+          name: 'Review',
+          tableName: 'Review',
+          fields: {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+            'productId': FieldInfo(
+                name: 'productId', columnName: 'productId', type: 'String'),
+          },
+        ));
+        nestedSchema.registerModel(const ModelSchema(
+          name: 'User',
+          tableName: 'users',
+          fields: {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+          },
+        ));
+        compiler = SqlCompiler(provider: 'postgresql', schema: nestedSchema);
+      });
+
+      test('to-one connect sets the FK inline on the main INSERT', () {
+        final query = JsonQueryBuilder()
+            .model('Product')
+            .action(QueryAction.create)
+            .data({
+          'id': 'p1',
+          'author': {
+            'connect': {'id': 'u1'}
+          },
+        }).build();
+
+        final compiled = compiler.compileWithRelations(query);
+        expect(compiled.mainQuery.sql, contains('authorId'));
+        expect(compiled.mainQuery.args, contains('u1'));
+        // connect-only to-one has no separate mutation
+        expect(compiled.relationMutations, isEmpty);
+      });
+
+      test('to-many create emits a child INSERT carrying the parent FK', () {
+        final query = JsonQueryBuilder()
+            .model('Product')
+            .action(QueryAction.create)
+            .data({
+          'id': 'p1',
+          'reviews': {
+            'create': [
+              {'id': 'r1'}
+            ]
+          },
+        }).build();
+
+        final compiled = compiler.compileWithRelations(query);
+        expect(compiled.relationMutations, hasLength(1));
+        final child = compiled.relationMutations.first;
+        expect(child.sql, contains('Review'));
+        expect(child.sql, contains('productId'));
+        expect(child.args, contains('p1'));
+      });
+
+      test('belongsTo create throws instead of silently dropping data', () {
+        final query = JsonQueryBuilder()
+            .model('Product')
+            .action(QueryAction.create)
+            .data({
+          'id': 'p1',
+          'author': {
+            'create': {'id': 'u1'}
+          },
+        }).build();
+
+        expect(() => compiler.compileWithRelations(query),
+            throwsA(isA<UnsupportedError>()));
+      });
+    });
   });
 }

--- a/test/unit/sql_compiler_test.dart
+++ b/test/unit/sql_compiler_test.dart
@@ -3925,5 +3925,127 @@ void main() {
             throwsA(isA<UnsupportedError>()));
       });
     });
+
+    group('Cursor pagination (#69)', () {
+      late SqlCompiler compiler;
+      setUp(() => compiler = SqlCompiler(provider: 'postgresql'));
+
+      test('single-field cursor asc -> inclusive >= predicate', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .orderBy({'id': 'asc'})
+            .cursor({'id': 'abc'})
+            .skip(1)
+            .build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('"id" >= \$1'));
+        expect(r.sql, contains('OFFSET 1'));
+        expect(r.args, equals(['abc']));
+      });
+
+      test('single-field cursor desc -> inclusive <= predicate', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .orderBy({'createdAt': 'desc'})
+            .cursor({'createdAt': 't'}).build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('"createdAt" <= \$1'));
+      });
+
+      test('multi-field cursor -> canonical keyset OR-expansion', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .orderBy([
+              {'score': 'desc'},
+              {'id': 'asc'}
+            ])
+            .cursor({'score': 10, 'id': 'x'})
+            .build();
+        final r = compiler.compile(q);
+        // (score < ?) OR (score = ? AND id >= ?)
+        expect(r.sql, contains('"score" < \$1'));
+        expect(r.sql, contains('"score" = \$2 AND "id" >= \$3'));
+        expect(r.args, equals([10, 10, 'x']));
+      });
+
+      test('cursor ANDs onto an existing WHERE', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({'published': true})
+            .orderBy({'id': 'asc'})
+            .cursor({'id': 'abc'}).build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('WHERE ('));
+        expect(r.sql, contains(') AND ('));
+        expect(r.args, equals([true, 'abc']));
+      });
+    });
+
+    group('JSON filters (#69)', () {
+      late SqlCompiler compiler;
+      setUp(() => compiler = SqlCompiler(provider: 'postgresql'));
+
+      test('path + equals -> #> ... = ?::jsonb', () {
+        final q = JsonQueryBuilder()
+            .model('Event')
+            .action(QueryAction.findMany)
+            .where({
+          'meta': {
+            'path': ['a', 'b'],
+            'equals': 'v'
+          }
+        }).build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('"meta" #> \'{a,b}\' = \$1::jsonb'));
+        expect(r.args, equals(['"v"']));
+      });
+
+      test('string_contains -> #>> ... LIKE', () {
+        final q = JsonQueryBuilder()
+            .model('Event')
+            .action(QueryAction.findMany)
+            .where({
+          'meta': {
+            'path': ['name'],
+            'string_contains': 'foo'
+          }
+        }).build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('"meta" #>> \'{name}\' LIKE \$1'));
+        expect(r.args, equals(['%foo%']));
+      });
+
+      test('array_contains -> @> ?::jsonb', () {
+        final q = JsonQueryBuilder()
+            .model('Event')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {
+            'array_contains': ['x']
+          }
+        }).build();
+        final r = compiler.compile(q);
+        expect(r.sql, contains('"tags" @> \$1::jsonb'));
+        expect(r.args, equals(['["x"]']));
+      });
+
+      test('non-postgres provider rejects JSON filters', () {
+        final sqlite = SqlCompiler(provider: 'sqlite');
+        final q = JsonQueryBuilder()
+            .model('Event')
+            .action(QueryAction.findMany)
+            .where({
+          'meta': {
+            'path': ['a'],
+            'equals': 1
+          }
+        }).build();
+        expect(() => sqlite.compile(q), throwsA(isA<UnsupportedError>()));
+      });
+    });
   });
 }

--- a/test/unit/sql_compiler_test.dart
+++ b/test/unit/sql_compiler_test.dart
@@ -3621,5 +3621,132 @@ void main() {
         );
       });
     });
+
+    group('to-one relation filters (is/isNot)', () {
+      late SqlCompiler c;
+
+      setUp(() {
+        final schema = SchemaRegistry();
+        schema.registerModel(const ModelSchema(
+          name: 'Product',
+          tableName: 'Product',
+          fields: {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+            'name': FieldInfo(name: 'name', columnName: 'name', type: 'String'),
+          },
+        ));
+        schema.registerModel(ModelSchema(
+          name: 'Review',
+          tableName: 'Review',
+          fields: const {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+            'productId': FieldInfo(
+                name: 'productId', columnName: 'productId', type: 'String'),
+          },
+          relations: {
+            'product': RelationInfo.manyToOne(
+              name: 'product',
+              targetModel: 'Product',
+              foreignKey: 'productId',
+            ),
+          },
+        ));
+        c = SqlCompiler(provider: 'postgresql', schema: schema);
+      });
+
+      test('is: {cond} -> EXISTS on the to-one target', () {
+        final q = JsonQueryBuilder()
+            .model('Review')
+            .action(QueryAction.findMany)
+            .where({
+          'product': {
+            'is': {'name': 'Widget'}
+          }
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('EXISTS'));
+        expect(r.sql, isNot(contains('NOT EXISTS')));
+        expect(r.sql, contains('FROM "Product"'));
+        expect(r.args, ['Widget']);
+      });
+
+      test('isNot: {cond} -> NOT EXISTS on the to-one target', () {
+        final q = JsonQueryBuilder()
+            .model('Review')
+            .action(QueryAction.findMany)
+            .where({
+          'product': {
+            'isNot': {'name': 'Widget'}
+          }
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('NOT EXISTS'));
+        expect(r.args, ['Widget']);
+      });
+
+      test('is: null -> NOT EXISTS (relation absent)', () {
+        final q = JsonQueryBuilder()
+            .model('Review')
+            .action(QueryAction.findMany)
+            .where({
+          'product': {'is': null}
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('NOT EXISTS'));
+      });
+
+      test('isNot: null -> EXISTS (relation present)', () {
+        final q = JsonQueryBuilder()
+            .model('Review')
+            .action(QueryAction.findMany)
+            .where({
+          'product': {'isNot': null}
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('EXISTS'));
+        expect(r.sql, isNot(contains('NOT EXISTS')));
+      });
+
+      test('is/isNot on a to-many relation throws', () {
+        final schema = SchemaRegistry();
+        schema.registerModel(ModelSchema(
+          name: 'Product',
+          tableName: 'Product',
+          fields: const {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+          },
+          relations: {
+            'reviews': RelationInfo.oneToMany(
+              name: 'reviews',
+              targetModel: 'Review',
+              foreignKey: 'productId',
+            ),
+          },
+        ));
+        schema.registerModel(const ModelSchema(
+          name: 'Review',
+          tableName: 'Review',
+          fields: {
+            'id': FieldInfo(
+                name: 'id', columnName: 'id', type: 'String', isId: true),
+            'productId': FieldInfo(
+                name: 'productId', columnName: 'productId', type: 'String'),
+          },
+        ));
+        final cc = SqlCompiler(provider: 'postgresql', schema: schema);
+        final q = JsonQueryBuilder()
+            .model('Product')
+            .action(QueryAction.findMany)
+            .where({
+          'reviews': {
+            'is': {'id': 'x'}
+          }
+        }).build();
+        expect(() => cc.compile(q), throwsArgumentError);
+      });
+    });
   });
 }

--- a/test/unit/sql_compiler_test.dart
+++ b/test/unit/sql_compiler_test.dart
@@ -3845,7 +3845,9 @@ void main() {
           },
           relations: {
             'reviews': RelationInfo.oneToMany(
-                name: 'reviews', targetModel: 'Review', foreignKey: 'productId'),
+                name: 'reviews',
+                targetModel: 'Review',
+                foreignKey: 'productId'),
             'author': RelationInfo.manyToOne(
                 name: 'author', targetModel: 'User', foreignKey: 'authorId'),
           },
@@ -3948,8 +3950,7 @@ void main() {
         final q = JsonQueryBuilder()
             .model('Post')
             .action(QueryAction.findMany)
-            .orderBy({'createdAt': 'desc'})
-            .cursor({'createdAt': 't'}).build();
+            .orderBy({'createdAt': 'desc'}).cursor({'createdAt': 't'}).build();
         final r = compiler.compile(q);
         expect(r.sql, contains('"createdAt" <= \$1'));
       });
@@ -3959,11 +3960,9 @@ void main() {
             .model('Post')
             .action(QueryAction.findMany)
             .orderBy([
-              {'score': 'desc'},
-              {'id': 'asc'}
-            ])
-            .cursor({'score': 10, 'id': 'x'})
-            .build();
+          {'score': 'desc'},
+          {'id': 'asc'}
+        ]).cursor({'score': 10, 'id': 'x'}).build();
         final r = compiler.compile(q);
         // (score < ?) OR (score = ? AND id >= ?)
         expect(r.sql, contains('"score" < \$1'));
@@ -3975,9 +3974,8 @@ void main() {
         final q = JsonQueryBuilder()
             .model('Post')
             .action(QueryAction.findMany)
-            .where({'published': true})
-            .orderBy({'id': 'asc'})
-            .cursor({'id': 'abc'}).build();
+            .where({'published': true}).orderBy({'id': 'asc'}).cursor(
+                {'id': 'abc'}).build();
         final r = compiler.compile(q);
         expect(r.sql, contains('WHERE ('));
         expect(r.sql, contains(') AND ('));

--- a/test/unit/sql_compiler_test.dart
+++ b/test/unit/sql_compiler_test.dart
@@ -3622,6 +3622,85 @@ void main() {
       });
     });
 
+    group('scalar-list (array) filters', () {
+      final c = SqlCompiler(provider: 'postgresql');
+
+      test('has -> = ANY(col)', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {'has': 'dart'}
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('= ANY("tags")'));
+        expect(r.args, ['dart']);
+      });
+
+      test('hasSome -> && ARRAY[...]', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {
+            'hasSome': ['a', 'b']
+          }
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('"tags" && ARRAY['));
+        expect(r.args, ['a', 'b']);
+      });
+
+      test('hasEvery -> @> ARRAY[...]', () {
+        final q = JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {
+            'hasEvery': ['a', 'b']
+          }
+        }).build();
+        final r = c.compile(q);
+        expect(r.sql, contains('"tags" @> ARRAY['));
+        expect(r.args, ['a', 'b']);
+      });
+
+      test('isEmpty true/false -> cardinality', () {
+        final empty = c.compile(JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {'isEmpty': true}
+        }).build());
+        expect(empty.sql, contains('cardinality("tags"), 0) = 0'));
+
+        final nonEmpty = c.compile(JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {'isEmpty': false}
+        }).build());
+        expect(nonEmpty.sql, contains('cardinality("tags"), 0) > 0'));
+      });
+
+      test('hasSome [] overlaps nothing; hasEvery [] matches all', () {
+        final some = c.compile(JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {'hasSome': <String>[]}
+        }).build());
+        expect(some.sql, contains('(1=0)'));
+        final every = c.compile(JsonQueryBuilder()
+            .model('Post')
+            .action(QueryAction.findMany)
+            .where({
+          'tags': {'hasEvery': <String>[]}
+        }).build());
+        expect(every.sql, contains('(1=1)'));
+      });
+    });
+
     group('to-one relation filters (is/isNot)', () {
       late SqlCompiler c;
 

--- a/test/unit/sql_compiler_updated_at_test.dart
+++ b/test/unit/sql_compiler_updated_at_test.dart
@@ -89,6 +89,42 @@ void main() {
     });
   });
 
+  group('UPSERT autofills @default + @updatedAt', () {
+    test('create arm fills uuid id + createdAt + updatedAt', () {
+      final compiler = SqlCompiler(provider: 'postgresql', schema: registry);
+      final query = JsonQueryBuilder()
+          .model('Plan')
+          .action(QueryAction.upsert)
+          .where({'id': 'p1'}).data({
+        'create': {'title': 'Mock'},
+        'update': {'title': 'Renamed'},
+      }).build();
+
+      final result = compiler.compile(query);
+
+      expect(result.sql, contains('INSERT INTO "Plan"'));
+      expect(result.sql, contains('gen_random_uuid()'));
+      // updatedAt appears in both the INSERT values and the DO UPDATE SET
+      expect('NOW()'.allMatches(result.sql).length, greaterThanOrEqualTo(2));
+      expect(result.sql, contains('ON CONFLICT ("id")'));
+      expect(result.sql, contains('DO UPDATE SET'));
+    });
+
+    test('update arm refreshes @updatedAt even when caller omits it', () {
+      final compiler = SqlCompiler(provider: 'postgresql', schema: registry);
+      final query = JsonQueryBuilder()
+          .model('Plan')
+          .action(QueryAction.upsert)
+          .where({'id': 'p1'}).data({
+        'create': {'title': 'Mock'},
+        'update': {'title': 'Renamed'},
+      }).build();
+
+      final result = compiler.compile(query);
+      expect(result.sql, contains('"updatedAt" = NOW()'));
+    });
+  });
+
   group('UPDATE refreshes @updatedAt', () {
     test('absent updatedAt is auto-set in SET clause', () {
       final compiler = SqlCompiler(provider: 'postgresql', schema: registry);


### PR DESCRIPTION
## prisma_flutter_connector v0.7.0 — the complete ORM

Upgrades the connector from a partial ORM to a complete one: the typed
`PrismaClient` surface now covers everything application code needs, so
hand-built `JsonQueryBuilder`/raw queries are no longer required. This is the
prerequisite for retiring all 285 `JsonQueryBuilder` + 66 raw-delegate sites in
`familiarise_mobile`.

### What's new

**Transactions (#68)** — `$transaction((tx) async { … })` runs through a
polymorphic `runTransaction`; nested `$transaction` flattens onto the ambient
transaction instead of crashing. `$disconnect()` routes through `dispose()`.

**Upsert (#66)** — `upsert({where, create, update})` over `INSERT … ON CONFLICT`
with `@map` conflict-column resolution and `@default`/`@updatedAt` autofill on
both arms. Guarded on models with a unique (incl. composite) key.

**Aggregate (#65)** — `aggregate()` (`_count/_avg/_sum/_min/_max`, `HAVING`) with
`@map`-resolved args, plus the missing `findFirstOrThrow` delegate.

**Composite unique / `@@id` / `@@unique` (#C6)** — generated compound
`WhereUniqueInput` classes let `findUnique/update/delete/upsert` target composite
keys; the compound `toJson` flattens to field equalities so the compiler needs no
compound-key awareness (and upsert gets the right multi-column `ON CONFLICT`).

**Typed include + relation hydration (#67)** — `fromJson` hydrates nested
relations into typed models (to-one → `Related?`, to-many → `List<Related>`), and
generated `XInclude` classes give the finders a typed `include:` argument —
retiring `findManyRaw`/`findFirstRaw` for typed results.

**Full nested writes (#64)** — Create/Update inputs carry a
`<Model><Relation>WriteInput` per relation (`connect`/`disconnect`/`create`);
`create`/`update` route to an atomic relations engine that resolves the parent PK
from the main mutation's `RETURNING` row (fixes DB-generated-uuid parents). To-one
`connect` inlines the FK; to-many `create` emits child INSERTs. A belongsTo
`create` throws `UnsupportedError` (parent-first ordering the engine can't
express) rather than silently dropping data.

**Filters (#69)** — cursor pagination (`cursor:` → canonical keyset predicate from
the cursor + `orderBy`, inclusive; pair with `skip: 1`); scalar-list
`has/hasSome/hasEvery/isEmpty`; PostgreSQL JSON(B) filters (`path` via `#>`/`#>>`,
`equals`, `string_contains/_starts_with/_ends_with`, `array_contains`, numeric
comparisons); `BigIntFilter` + `BytesFilter`.

**Connection pooling (#70)** — `PostgresAdapter.pooled(pg.Pool)` runs
non-transactional statements on borrowed connections; each transaction pins one
dedicated pool connection for its lifetime (`withConnection` + a release
completer) so all statements share one physical connection.

**Other ORM gaps** — atomic numeric updates
(`{increment/decrement/multiply/divide/set}` → `col = col ± ?`);
`createManyAndReturn` + `skipDuplicates` (`ON CONFLICT DO NOTHING`); a nested
include depth guard (`maxIncludeDepth = 5`).

### Fixes
- `@map` resolution in the previously-missed write paths (#C3): upsert conflict
  columns, groupBy/aggregate fields, and m2m connect/disconnect + `EXISTS`.
- To-one relation filters `is`/`isNot` in `where` now compile (#C2) instead of
  throwing; `is`/`isNot` on a to-many relation is rejected.

### Verification
- **446 unit tests green**; `dart analyze lib` clean.
- `dart pub publish --dry-run` → **0 warnings** (publish-ready).
- **Full-schema compile smoke**: generated the real 127-table backend schema
  through the v0.7.0 generator + freezed 2.x `build_runner` → **0 errors,
  0 warnings** across the entire generated client. Generator output cleaned so
  the mobile build stays warning-free (dropped unused imports, self-imports, and
  `invalid_annotation_target` noise).

### Notes / intentional scope
- Batch `$transaction([…])` (array form) is **not** provided: delegate methods
  execute eagerly (no lazy promises), so only the callback form is sound.
- Soft-delete stays a documented `deletedAt: null` filter pattern; full
  `$extends` middleware is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded “complete-ORM” support: nested relation hydration and writes, composite unique (`@@id`/`@@unique`) upserts and where-unique inputs, deeper typed includes, aggregates/groupBy, and `createManyAndReturn`.
  * Added keyset cursor pagination, `skipDuplicates` for `createMany`/`createManyAndReturn`, and atomic numeric updates.
  * Introduced Sentry-backed query logging with optional parameter capture.
* **Bug Fixes**
  * Improved `@map` handling across writes, aggregates, and upserts; fixed relation `is`/`isNot` filter compilation.
  * Corrected pooled-transaction behavior and preserved raw column names in map results; added nested include depth guard.
* **Tests**
  * Broadened unit coverage for generation, SQL compilation, pagination, pooling, nested writes, atomic updates, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->