### PR TITLE
feat: v0.8.0 — typed projection (ScalarField enums, include-select, projected finders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to the Prisma Flutter Connector.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-03
+
+The **typed-projection** release: the last raw-map surfaces (`select`,
+`selectFields`, `distinct`, computed fields, map-based include) now have typed
+equivalents, completing the surface needed to retire hand-built
+`JsonQueryBuilder` usage entirely.
+
+### Added
+
+#### `{Model}ScalarField` enums
+- One plain enum per model (a case per scalar field, carrying the Dart field
+  name; the compiler resolves `@map` columns via the registry). Near-zero
+  codegen cost — no freezed/part files.
+
+#### Typed per-relation include `select`
+- `XInclude` gains `select: List<{Model}ScalarField>?`, applied when the
+  include is nested under a parent include:
+  `AuthorInclude(posts: PostInclude(select: [PostScalarField.title]))`.
+  `toJson` emits `true` | `{'include': ..., 'select': ...}` — the shape the
+  relation compiler already consumes. `select` on the root include object is
+  ignored (root projection goes through the projected finders).
+
+#### `findManyProjected` / `findFirstProjected`
+- Fully-typed projection finders on every delegate: `XWhereInput`,
+  `orderBy` (Map | List | `XOrderByInput`), `take`/`skip`/`cursor`,
+  `XInclude` (with per-relation select), `select: List<XScalarField>`,
+  `computed: Map<String, ComputedField>`, `distinct`/`distinctOn:
+  List<XScalarField>` — with `Map<String, dynamic>` rows out (projected or
+  computed rows never hydrate typed models). This single surface replaces
+  every `.select()`/`.selectFields()`/computed/raw-helper call site.
+
+### Deprecated
+- **`findManyRaw` / `findFirstRaw`** — use the projected finders; removal
+  planned for 0.9.0.
+
+### Fixed
+- **Include-with-select dropped relation rows when the child primary key was
+  not selected** — the relation deserializer groups child rows by PK, so a
+  narrow `select` silently emptied the relation. PK columns are now always
+  carried in the aliased selection.
+
+### Notes
+- Nested typed relation filters (`XRelationFilter(is_:)` chains) compile to
+  correctly-correlated nested `EXISTS` — semantically equivalent to (and
+  better-correlated than) the legacy `FilterOperators.relationPath`, which is
+  now redundant. Limitation: repeating the SAME relation name along one chain
+  would collide on the `sub_<relation>` alias (not expressible with distinct
+  relation names).
+
 ## [0.7.1] - 2026-07-03
 
 ### Fixed

--- a/lib/src/generator/cb_delegate_generator.dart
+++ b/lib/src/generator/cb_delegate_generator.dart
@@ -70,6 +70,8 @@ class CbDelegateGenerator {
         _findFirst(modelName, tableName),
         _findFirstOrThrow(modelName),
         _findMany(modelName, tableName, hasUniqueFields),
+        _findManyProjected(modelName, tableName, hasUniqueFields),
+        _findFirstProjected(modelName, tableName),
         _findManyRaw(modelName, tableName),
         _findFirstRaw(modelName, tableName),
         _create(modelName, tableName, relLiteral),
@@ -265,8 +267,146 @@ class CbDelegateGenerator {
       return results.map((json) => $m.fromJson(_normalizeForJson(json))).toList();
     '''));
 
+  /// Fully-typed projection finder: typed where/include/select/distinct with
+  /// Map rows out (projected/computed rows never hydrate typed models).
+  Method _findManyProjected(String m, String t, bool hasUniqueFields) =>
+      Method((b) => b
+        ..name = 'findManyProjected'
+        ..docs.addAll([
+          '/// Find multiple ${m}s as projected rows (maps).',
+          '///',
+          '/// Typed inputs; `Map` rows out — use for scalar projection',
+          '/// (`select:`/`distinctOn:`), computed correlated subqueries, and',
+          '/// include-with-select. Rows may be partial, so they are not',
+          '/// hydrated into typed models.',
+        ])
+        ..modifier = MethodModifier.async
+        ..returns = refer('Future<List<Map<String, dynamic>>>')
+        ..optionalParameters.addAll([
+          Parameter((p) => p
+            ..name = 'where'
+            ..named = true
+            ..type = refer('${m}WhereInput?')),
+          Parameter((p) => p
+            ..name = 'orderBy'
+            ..named = true
+            ..type = refer('dynamic')),
+          Parameter((p) => p
+            ..name = 'take'
+            ..named = true
+            ..type = refer('int?')),
+          Parameter((p) => p
+            ..name = 'skip'
+            ..named = true
+            ..type = refer('int?')),
+          if (hasUniqueFields)
+            Parameter((p) => p
+              ..name = 'cursor'
+              ..named = true
+              ..type = refer('${m}WhereUniqueInput?')),
+          Parameter((p) => p
+            ..name = 'include'
+            ..named = true
+            ..type = refer('${m}Include?')),
+          Parameter((p) => p
+            ..name = 'select'
+            ..named = true
+            ..type = refer('List<${m}ScalarField>?')),
+          Parameter((p) => p
+            ..name = 'computed'
+            ..named = true
+            ..type = refer('Map<String, ComputedField>?')),
+          Parameter((p) => p
+            ..name = 'distinct'
+            ..named = true
+            ..type = refer('bool?')),
+          Parameter((p) => p
+            ..name = 'distinctOn'
+            ..named = true
+            ..type = refer('List<${m}ScalarField>?')),
+        ])
+        ..body = Code('''
+      final queryBuilder = JsonQueryBuilder()
+          .model('$t')
+          .action(QueryAction.findMany);
+
+      if (where != null) queryBuilder.where(_whereToJson(where));
+      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy);
+      if (orderBy is List) queryBuilder.orderBy(orderBy);
+      if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy));
+      if (take != null) queryBuilder.take(take);
+      if (skip != null) queryBuilder.skip(skip);
+      ${hasUniqueFields ? 'if (cursor != null) queryBuilder.cursor(_whereUniqueToJson(cursor));' : ''}
+      if (include != null) queryBuilder.include(include.toJson());
+      if (select != null && select.isNotEmpty) {
+        queryBuilder.selectFields([for (final f in select) f.fieldName]);
+      }
+      if (computed != null) queryBuilder.computed(computed);
+      if (distinct == true || (distinctOn != null && distinctOn.isNotEmpty)) {
+        queryBuilder.distinct(
+          distinctOn == null || distinctOn.isEmpty
+              ? null
+              : [for (final f in distinctOn) f.fieldName],
+        );
+      }
+
+      return await _executor.executeQueryAsMaps(queryBuilder.build());
+    '''));
+
+  /// findFirst variant of [_findManyProjected].
+  Method _findFirstProjected(String m, String t) => Method((b) => b
+    ..name = 'findFirstProjected'
+    ..docs.addAll([
+      '/// Find the first $m as a projected row (map). See findManyProjected.',
+    ])
+    ..modifier = MethodModifier.async
+    ..returns = refer('Future<Map<String, dynamic>?>')
+    ..optionalParameters.addAll([
+      Parameter((p) => p
+        ..name = 'where'
+        ..named = true
+        ..type = refer('${m}WhereInput?')),
+      Parameter((p) => p
+        ..name = 'orderBy'
+        ..named = true
+        ..type = refer('dynamic')),
+      Parameter((p) => p
+        ..name = 'include'
+        ..named = true
+        ..type = refer('${m}Include?')),
+      Parameter((p) => p
+        ..name = 'select'
+        ..named = true
+        ..type = refer('List<${m}ScalarField>?')),
+      Parameter((p) => p
+        ..name = 'computed'
+        ..named = true
+        ..type = refer('Map<String, ComputedField>?')),
+    ])
+    ..body = Code('''
+      final queryBuilder = JsonQueryBuilder()
+          .model('$t')
+          .action(QueryAction.findFirst);
+
+      if (where != null) queryBuilder.where(_whereToJson(where));
+      if (orderBy is Map<String, dynamic>) queryBuilder.orderBy(orderBy);
+      if (orderBy is List) queryBuilder.orderBy(orderBy);
+      if (orderBy is ${m}OrderByInput) queryBuilder.orderBy(_orderByToJson(orderBy));
+      if (include != null) queryBuilder.include(include.toJson());
+      if (select != null && select.isNotEmpty) {
+        queryBuilder.selectFields([for (final f in select) f.fieldName]);
+      }
+      if (computed != null) queryBuilder.computed(computed);
+
+      return await _executor.executeQueryAsSingleMap(queryBuilder.build());
+    '''));
+
   Method _findManyRaw(String m, String t) => Method((b) => b
     ..name = 'findManyRaw'
+    ..annotations.add(CodeExpression(
+        Code("Deprecated('Use findManyProjected (typed inputs) instead; "
+            'findManyRaw will be removed in 0.9.0'
+            "')")))
     ..docs
         .add('/// Find multiple ${m}s as raw maps (use with include/computed)')
     ..modifier = MethodModifier.async
@@ -334,6 +474,10 @@ class CbDelegateGenerator {
 
   Method _findFirstRaw(String m, String t) => Method((b) => b
     ..name = 'findFirstRaw'
+    ..annotations.add(CodeExpression(
+        Code("Deprecated('Use findFirstProjected (typed inputs) instead; "
+            'findFirstRaw will be removed in 0.9.0'
+            "')")))
     ..docs.add('/// Find the first $m as a raw map (use with include/computed)')
     ..modifier = MethodModifier.async
     ..returns = refer('Future<Map<String, dynamic>?>')

--- a/lib/src/generator/cb_model_generator.dart
+++ b/lib/src/generator/cb_model_generator.dart
@@ -55,6 +55,7 @@ class CbModelGenerator {
         _buildListRelationFilter(model),
         _buildRelationFilter(model),
         _buildOrderByInput(model),
+        _buildScalarFieldEnum(model),
         _buildInclude(model),
         ..._buildRelationWriteInputs(model),
         ..._buildEnumConverters(model),
@@ -754,17 +755,63 @@ class CbModelGenerator {
     return specs;
   }
 
+  // === Scalar-field enum (typed projection) ===
+
+  /// Enum-case name for a scalar field, avoiding the identifiers every Dart
+  /// enum already declares (`values`, `index`, …).
+  String _scalarEnumCase(String name) {
+    const reserved = {
+      'values',
+      'index',
+      'hashCode',
+      'runtimeType',
+      'toString',
+      'noSuchMethod',
+    };
+    return reserved.contains(name) ? '${name}Field' : name;
+  }
+
+  /// Plain enum `{Model}ScalarField` — one case per scalar (non-relation)
+  /// field, carrying the Dart field name for the compiler to resolve via the
+  /// registry (@map-aware). Used by typed projection (`select:`/`distinctOn:`)
+  /// and per-relation include `select`.
+  Spec _buildScalarFieldEnum(PrismaModel model) {
+    final scalars = model.fields.where((f) => !f.isRelation).toList();
+    final cases = scalars
+        .map((f) => "  ${_scalarEnumCase(f.name)}('${f.name}')")
+        .join(',\n');
+    return Code('''
+/// Scalar fields of ${model.name} for typed projection.
+enum ${model.name}ScalarField {
+$cases;
+
+  const ${model.name}ScalarField(this.fieldName);
+
+  /// The Dart field name (the compiler resolves @map columns via the registry).
+  final String fieldName;
+}
+''');
+  }
+
   // === Include (typed relation selection) ===
 
-  /// Typed include class: one `${RelatedModel}Include?` field per relation.
-  /// A non-null nested include includes that relation (empty = include with no
-  /// deeper relations); toJson yields the compiler's include-map shape.
+  /// Typed include class: one `${RelatedModel}Include?` field per relation,
+  /// plus `select` (that model's own scalar fields) applied when this include
+  /// is NESTED under a parent include. A non-null nested include includes that
+  /// relation; toJson yields the compiler's include-map shape:
+  /// `true` | `{'include': ..., 'select': ...}`.
+  ///
+  /// NOTE: `select` on the ROOT include object of a query is ignored — root
+  /// projection goes through the finder's own `select` parameter
+  /// (findManyProjected).
   Class _buildInclude(PrismaModel model) {
     final relations = model.fields.where((f) => f.isRelation).toList();
-    final params = <Parameter>[];
-    // Statement-style toJson (no runtime helper): an empty nested include
-    // serializes to `true` (include, no deeper relations); a non-empty one
-    // nests via {'include': ...}, matching the relation compiler's shape.
+    final params = <Parameter>[
+      Parameter((p) => p
+        ..name = 'select'
+        ..named = true
+        ..type = refer('List<${model.name}ScalarField>?')),
+    ];
     final stmts = <String>['final map = <String, dynamic>{};'];
     for (final f in relations) {
       params.add(Parameter((p) => p
@@ -773,13 +820,29 @@ class CbModelGenerator {
         ..type = refer('${f.type}Include?')));
       stmts.add("if (${f.name} != null) {"
           " final n = ${f.name}!.toJson();"
-          " map['${f.name}'] = n.isEmpty ? true : <String, dynamic>{'include': n};"
+          " final s = ${f.name}!.selectMap();"
+          " map['${f.name}'] = (n.isEmpty && s == null)"
+          "     ? true"
+          "     : <String, dynamic>{"
+          "         if (n.isNotEmpty) 'include': n,"
+          "         if (s != null) 'select': s,"
+          "       };"
           " }");
     }
     stmts.add('return map;');
     return _freezedClass('${model.name}Include', params,
         doc: '/// Typed include for ${model.name} relations',
-        toJsonBody: stmts.join('\n'));
+        toJsonBody: stmts.join('\n'),
+        extraMethods: [
+          Method((m) => m
+            ..docs.add('/// Scalar projection for this include when nested '
+                'under a parent include; null = all fields.')
+            ..name = 'selectMap'
+            ..returns = refer('Map<String, dynamic>?')
+            ..body = Code('if (select == null || select!.isEmpty) return null;'
+                ' return <String, dynamic>{'
+                'for (final f in select!) f.fieldName: true};')),
+        ]);
   }
 
   // === OrderByInput ===
@@ -809,7 +872,9 @@ class CbModelGenerator {
   // === Shared: build a @freezed class ===
 
   Class _freezedClass(String name, List<Parameter> params,
-      {String? doc, required String toJsonBody}) {
+      {String? doc,
+      required String toJsonBody,
+      List<Method> extraMethods = const []}) {
     return Class((b) {
       if (doc != null) b.docs.add(doc);
       b
@@ -836,10 +901,13 @@ class CbModelGenerator {
             ..body =
                 Code("throw UnimplementedError('$name.fromJson not needed');")),
         ])
-        ..methods.add(Method((m) => m
-          ..name = 'toJson'
-          ..returns = refer('Map<String, dynamic>')
-          ..body = Code(toJsonBody)));
+        ..methods.addAll([
+          Method((m) => m
+            ..name = 'toJson'
+            ..returns = refer('Map<String, dynamic>')
+            ..body = Code(toJsonBody)),
+          ...extraMethods,
+        ]);
     });
   }
 

--- a/lib/src/runtime/query/relation_compiler.dart
+++ b/lib/src/runtime/query/relation_compiler.dart
@@ -463,7 +463,16 @@ class RelationCompiler {
       fieldToColumn[field.name] = field.columnName;
     }
 
-    for (final fieldName in selectedFields) {
+    // Always carry the primary key: the relation deserializer groups/dedupes
+    // child rows by PK, so a select that omits it would silently drop the
+    // relation's rows from the hydrated result.
+    final effectiveFields = [
+      ...selectedFields,
+      for (final pk in model.primaryKeys)
+        if (!selectedFields.contains(pk.name)) pk.name,
+    ];
+
+    for (final fieldName in effectiveFields) {
       // Get actual column name (may differ from field name)
       final columnName = fieldToColumn[fieldName] ?? fieldName;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A type-safe Flutter connector for Prisma backends. Generate Dart models
   and type-safe APIs from your Prisma schema with support for PostgreSQL,
   MySQL, SQLite, and Supabase.
-version: 0.7.1
+version: 0.8.0
 homepage: https://github.com/teetangh/prisma-flutter-connector
 repository: https://github.com/teetangh/prisma-flutter-connector
 issue_tracker: https://github.com/teetangh/prisma-flutter-connector/issues

--- a/test/unit/model_generator_include_test.dart
+++ b/test/unit/model_generator_include_test.dart
@@ -61,12 +61,29 @@ void main() {
       expect(flat, contains('class PostInclude'));
       expect(flat, contains('UserInclude? author'));
       expect(flat, contains('CommentInclude? comments'));
-      // toJson nests empty-include -> true, else {'include': ...}
+      // toJson nests empty-include -> true, else {'include': ..., 'select': ...}
       expect(flat, contains('final n = author!.toJson();'));
-      expect(
-          flat,
-          contains(
-              "map['author'] = n.isEmpty ? true : <String, dynamic>{'include': n}"));
+      expect(flat, contains('final s = author!.selectMap();'));
+      expect(flat, contains("map['author'] = (n.isEmpty && s == null) ? true"));
+      expect(flat, contains("if (n.isNotEmpty) 'include': n"));
+      expect(flat, contains("if (s != null) 'select': s"));
+    });
+
+    test('XInclude has typed per-relation select + ScalarField enum (#0.8.0)',
+        () {
+      final flat = _flat(modelCode('Post'));
+      // Include carries its own model's scalar-field select list
+      expect(flat, contains('List<PostScalarField>? select'));
+      // ScalarField enum generated with case-per-scalar + fieldName payload
+      expect(flat, contains('enum PostScalarField'));
+      expect(flat, contains("title('title')"));
+      expect(flat, contains("authorId('authorId')"));
+      // relations are NOT scalar cases
+      expect(flat, isNot(contains("author('author')")));
+      // selectMap emits {'field': true} or null
+      expect(flat,
+          contains('if (select == null || select!.isEmpty) return null;'));
+      expect(flat, contains('for (final f in select!) f.fieldName: true'));
     });
 
     test('relation-less model gets an empty XInclude', () {

--- a/test/unit/typed_projection_test.dart
+++ b/test/unit/typed_projection_test.dart
@@ -1,0 +1,224 @@
+import 'package:test/test.dart';
+import 'package:prisma_flutter_connector/src/generator/cb_delegate_generator.dart';
+import 'package:prisma_flutter_connector/src/generator/prisma_parser.dart';
+import 'package:prisma_flutter_connector/src/runtime/query/sql_compiler.dart';
+import 'package:prisma_flutter_connector/src/runtime/query/json_protocol.dart';
+import 'package:prisma_flutter_connector/src/runtime/adapters/types.dart';
+import 'package:prisma_flutter_connector/src/runtime/schema/schema_registry.dart';
+
+String _flat(String code) => code.replaceAll(RegExp(r'\s+'), ' ');
+
+/// Registry mirroring slot_repository's chain:
+/// Slot -> appointment (N:1) -> consultation (1:1) -> consultationPlan (1:N).
+SchemaRegistry _chainRegistry() {
+  final s = SchemaRegistry();
+  s.registerModel(ModelSchema(name: 'Slot', tableName: 'Slot', fields: {
+    'id': const FieldInfo(
+        name: 'id', columnName: 'id', type: 'String', isId: true),
+    'appointmentId': const FieldInfo(
+        name: 'appointmentId', columnName: 'appointmentId', type: 'String'),
+  }, relations: {
+    'appointment': RelationInfo.manyToOne(
+        name: 'appointment',
+        targetModel: 'Appointment',
+        foreignKey: 'appointmentId'),
+  }));
+  s.registerModel(
+      ModelSchema(name: 'Appointment', tableName: 'Appointment', fields: {
+    'id': const FieldInfo(
+        name: 'id', columnName: 'id', type: 'String', isId: true),
+  }, relations: {
+    'consultation': RelationInfo.oneToOne(
+        name: 'consultation',
+        targetModel: 'Consultation',
+        foreignKey: 'appointmentId'),
+  }));
+  s.registerModel(
+      ModelSchema(name: 'Consultation', tableName: 'Consultation', fields: {
+    'id': const FieldInfo(
+        name: 'id', columnName: 'id', type: 'String', isId: true),
+    'appointmentId': const FieldInfo(
+        name: 'appointmentId', columnName: 'appointmentId', type: 'String'),
+    'requestStatus': const FieldInfo(
+        name: 'requestStatus', columnName: 'requestStatus', type: 'String'),
+  }, relations: {
+    'consultationPlan': RelationInfo.oneToMany(
+        name: 'consultationPlan',
+        targetModel: 'Plan',
+        foreignKey: 'consultationId'),
+  }));
+  s.registerModel(const ModelSchema(name: 'Plan', tableName: 'Plan', fields: {
+    'id': FieldInfo(name: 'id', columnName: 'id', type: 'String', isId: true),
+    'consultationId': FieldInfo(
+        name: 'consultationId', columnName: 'consultationId', type: 'String'),
+    'consultantProfileId': FieldInfo(
+        name: 'consultantProfileId',
+        columnName: 'consultantProfileId',
+        type: 'String'),
+  }));
+  return s;
+}
+
+const _innerWhere = {
+  'consultationPlan': {
+    'some': {'consultantProfileId': 'c1'}
+  },
+  'requestStatus': {
+    'in': ['PENDING', 'APPROVED']
+  },
+};
+
+void main() {
+  group('nested typed relation filters replace relationPath (#0.8.0)', () {
+    late SqlCompiler compiler;
+    setUp(() => compiler =
+        SqlCompiler(provider: 'postgresql', schema: _chainRegistry()));
+
+    SqlQuery nested() => compiler.compile(JsonQueryBuilder()
+            .model('Slot')
+            .action(QueryAction.findMany)
+            .where({
+          'appointment': {
+            'is': {
+              'consultation': {'is': _innerWhere}
+            }
+          }
+        }).build());
+
+    SqlQuery viaPath() => compiler.compile(JsonQueryBuilder()
+            .model('Slot')
+            .action(QueryAction.findMany)
+            .where({
+          '_relationPath': 'appointment.consultation',
+          '_relationWhere': _innerWhere,
+        }).build());
+
+    test('nested typed shape compiles to correctly-correlated nested EXISTS',
+        () {
+      final r = nested();
+      // 3 EXISTS levels: appointment -> consultation -> consultationPlan
+      expect('EXISTS'.allMatches(r.sql).length, 3);
+      // each level correlates to its immediate parent alias
+      expect(r.sql, contains('sub_appointment."id" = "Slot"."appointmentId"'));
+      expect(r.sql,
+          contains('sub_consultation."appointmentId" = sub_appointment."id"'));
+      expect(
+          r.sql,
+          contains(
+              'sub_consultationPlan."consultationId" = sub_consultation."id"'));
+      expect(r.args, equals(['c1', 'PENDING', 'APPROVED']));
+    });
+
+    test('semantic equivalence with legacy relationPath (same filters + args)',
+        () {
+      final a = nested();
+      final b = viaPath();
+      // Both are EXISTS-based semijoins over the same tables with the same
+      // parameters (structures differ: nested EXISTS vs JOIN-chain EXISTS).
+      for (final sql in [a.sql, b.sql]) {
+        expect(sql, contains('"Appointment"'));
+        expect(sql, contains('"Consultation"'));
+        expect(sql, contains('"Plan"'));
+        expect(sql, contains('EXISTS'));
+      }
+      expect(a.args, equals(b.args));
+    });
+
+    test('aliases stay distinct along a chain of distinct relation names', () {
+      final r = nested();
+      // sub_<relationName> is unique per level here; a collision could only
+      // occur if the SAME relation name repeated along one chain (documented
+      // limitation — not exercised by the app schema).
+      expect(r.sql, contains('sub_appointment'));
+      expect(r.sql, contains('sub_consultation'));
+      expect(r.sql, contains('sub_consultationPlan'));
+    });
+  });
+
+  group('include with per-relation select compiles to projected columns', () {
+    test('select sub-map limits the relation columns in the SELECT list', () {
+      final s = SchemaRegistry();
+      s.registerModel(ModelSchema(name: 'Post', tableName: 'Post', fields: {
+        'id': const FieldInfo(
+            name: 'id', columnName: 'id', type: 'String', isId: true),
+        'title':
+            const FieldInfo(name: 'title', columnName: 'title', type: 'String'),
+        'authorId': const FieldInfo(
+            name: 'authorId', columnName: 'authorId', type: 'String'),
+      }, relations: {
+        'author': RelationInfo.manyToOne(
+            name: 'author', targetModel: 'User', foreignKey: 'authorId'),
+      }));
+      s.registerModel(
+          const ModelSchema(name: 'User', tableName: 'User', fields: {
+        'id':
+            FieldInfo(name: 'id', columnName: 'id', type: 'String', isId: true),
+        'name': FieldInfo(name: 'name', columnName: 'name', type: 'String'),
+        'secret':
+            FieldInfo(name: 'secret', columnName: 'secret', type: 'String'),
+      }));
+      final compiler = SqlCompiler(provider: 'postgresql', schema: s);
+
+      // Shape emitted by XInclude.toJson() when a nested include has select:
+      final q = JsonQueryBuilder()
+          .model('Post')
+          .action(QueryAction.findMany)
+          .include({
+        'author': {
+          'select': {'name': true}
+        }
+      }).build();
+      final r = compiler.compile(q);
+
+      expect(r.sql, contains('"author__name"'));
+      expect(r.sql, isNot(contains('"author__secret"')));
+    });
+  });
+
+  group('projected finders generation (#0.8.0)', () {
+    const schema = '''
+model Post {
+  id       String @id
+  title    String
+  views    Int
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId String
+}
+model User { id String @id }
+''';
+
+    String delegate() {
+      final parsed = PrismaParser().parse(schema);
+      return CbDelegateGenerator(parsed, serverMode: true)
+          .generateDelegate(parsed.models.first);
+    }
+
+    test('findManyProjected has typed inputs and selectFields wiring', () {
+      final flat = _flat(delegate());
+      expect(flat,
+          contains('Future<List<Map<String, dynamic>>> findManyProjected'));
+      expect(flat, contains('PostWhereInput? where'));
+      expect(flat, contains('List<PostScalarField>? select'));
+      expect(flat, contains('Map<String, ComputedField>? computed'));
+      expect(flat, contains('List<PostScalarField>? distinctOn'));
+      expect(flat, contains('PostWhereUniqueInput? cursor'));
+      expect(flat,
+          contains('selectFields([for (final f in select) f.fieldName])'));
+      expect(flat, contains('if (computed != null) queryBuilder.computed'));
+    });
+
+    test('findFirstProjected exists and returns a single map', () {
+      final flat = _flat(delegate());
+      expect(
+          flat, contains('Future<Map<String, dynamic>?> findFirstProjected'));
+      expect(flat, contains('executeQueryAsSingleMap'));
+    });
+
+    test('raw helpers are @Deprecated pointing at projected finders', () {
+      final flat = _flat(delegate());
+      expect(flat, contains('@Deprecated('));
+      expect(flat, contains("'Use findManyProjected (typed inputs) instead"));
+      expect(flat, contains("'Use findFirstProjected (typed inputs) instead"));
+    });
+  });
+}


### PR DESCRIPTION
## prisma_flutter_connector v0.8.0 — typed projection

Completes the typed surface for the last raw-map query shapes, so consumers can retire hand-built `JsonQueryBuilder` usage entirely. Zero runtime SQL changes — the engine already supported every shape; this release exposes them through the generated typed API (plus one deserializer-adjacent fix found by live testing).

### What's new

**`{Model}ScalarField` enums** — one plain enum per model (case per scalar field, carrying the Dart field name; `@map` resolution stays in the registry). No freezed/part-file cost.

**Typed per-relation include `select`** — `XInclude` gains `select: List<{Model}ScalarField>?`:
```dart
db.author.findManyProjected(
  include: AuthorInclude(posts: PostInclude(select: [PostScalarField.title])),
);
```
Emits `true` | `{'include': ..., 'select': ...}` — the shape the relation compiler already consumes.

**`findManyProjected` / `findFirstProjected`** — fully-typed projection finders on every delegate (`XWhereInput`, orderBy, take/skip/cursor, `XInclude`-with-select, `select: List<XScalarField>`, `computed: Map<String, ComputedField>`, `distinct`/`distinctOn`), returning `Map<String, dynamic>` rows — projected/computed rows never hydrate typed models. One surface replaces every `.select()` / `.selectFields()` / computed / raw-helper call site.

### Deprecated
- `findManyRaw` / `findFirstRaw` → use the projected finders (removal in 0.9.0).

### Fixed
- **Include-with-select silently dropped relation rows when the child PK wasn't selected** (the deserializer groups child rows by PK). PK columns are now always carried in the aliased selection. Found by the live-Postgres smoke.

### Verified
- 456 unit tests green; `flutter analyze --fatal-infos` clean; publish dry-run clean.
- New tests: nested typed relation filters compile to correctly-correlated nested `EXISTS`, semantically equivalent to legacy `FilterOperators.relationPath` (same tables + args) — with distinct `sub_<relation>` aliases (same-name chain repetition documented as a limitation); include-select → projected relation columns; projected-finder generation snapshot.
- Live smoke vs real Postgres: projected select / distinctOn / computed / include-with-select / nested typed relation filter / findFirstProjected — **6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typed scalar-field projections for models.
  - Added per-relation `select` support within `include`.
  - Introduced typed `findManyProjected` and `findFirstProjected` queries with filtering, selection, computed fields, distinct options, and cursors.

- **Bug Fixes**
  - Included relation records are now preserved when selected fields omit the child primary key.
  - Improved correlation for nested relation filters.

- **Deprecations**
  - Deprecated raw finder methods; use projected queries instead. Removal is planned for version 0.9.0.

- **Release**
  - Updated the package to version 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->